### PR TITLE
Import seaborn library in the  Similarity notebook

### DIFF
--- a/notebooks/What_Is_Similarity_Between_Sentences.ipynb
+++ b/notebooks/What_Is_Similarity_Between_Sentences.ipynb
@@ -34,6 +34,8 @@
         "import pandas as pd\n",
         "import numpy as np\n",
         "import altair as alt\n",
+         "import seaborn as sns\n",
+        
         "\n",
         "api_key = '' # Paste your API key here. Remember to not share it publicly \n",
         "co = cohere.Client(api_key)"


### PR DESCRIPTION
The "What_Is_Similarity_Between_Sentences.ipynb" notebook has a seaborn plot in the end, but the library is not imported. As a result, running the notebook throws an error. This notebook is also linked to the LLM university's 'Similarity Between Words and Sentences' module.