### PR TITLE
Fixed heading level of the Clustering subsection

### DIFF
--- a/notebooks/Visualizing_Text_Embeddings.ipynb
+++ b/notebooks/Visualizing_Text_Embeddings.ipynb
@@ -1009,7 +1009,7 @@
         "id": "GntvUvgRl-pm"
       },
       "source": [
-        "# 2.2 - Clustering\n"
+        "## 2.2 - Clustering\n"
       ]
     },
     {


### PR DESCRIPTION
The subsection on Clustering is at the moment heading of level 1. Changed that to level 2 in this PR.

<img width="1280" alt="Screenshot 2023-06-28 at 12 30 15" src="https://github.com/cohere-ai/notebooks/assets/2899501/90241455-7cc0-43ad-9839-4e378515726e">
