### PR TITLE
Fix wrong spanish results display for Arabic queries

### DIFF
--- a/notebooks/End_To_End_Wikipedia_Search.ipynb
+++ b/notebooks/End_To_End_Wikipedia_Search.ipynb
@@ -1,21 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "LSfTvkvzWDxd"
+      },
       "source": [
         "# Comparing different search methods for Wikipedia\n",
         "\n",
@@ -25,25 +14,20 @@
         "- Dense retrieval\n",
         "- Reranking\n",
         "Furthermore, we combine the power of search with Cohere's Generate endpoint in order to output accurate answers in sentence format to a query."
-      ],
-      "metadata": {
-        "id": "LSfTvkvzWDxd"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "# Imports"
-      ],
       "metadata": {
         "id": "D19hmGMAR78j"
-      }
+      },
+      "source": [
+        "# Imports"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!pip install cohere weaviate-client"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -51,11 +35,10 @@
         "id": "j63JHf4QSEv1",
         "outputId": "7b551cc4-15bc-49fc-90ed-f93fd38711eb"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Requirement already satisfied: cohere in /usr/local/lib/python3.10/dist-packages (4.27)\n",
             "Requirement already satisfied: weaviate-client in /usr/local/lib/python3.10/dist-packages (3.24.1)\n",
@@ -82,6 +65,9 @@
             "Requirement already satisfied: pycparser in /usr/local/lib/python3.10/dist-packages (from cffi>=1.12->cryptography>=3.2->authlib<2.0.0,>=1.2.1->weaviate-client) (2.21)\n"
           ]
         }
+      ],
+      "source": [
+        "!pip install cohere weaviate-client"
       ]
     },
     {
@@ -96,14 +82,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "True"
             ]
           },
+          "execution_count": 8,
           "metadata": {},
-          "execution_count": 8
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -132,6 +118,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "YtKPrTy7SLrG"
+      },
       "source": [
         "# Keyword Search\n",
         "\n",
@@ -142,13 +131,15 @@
         "- Hard query: Who was the first person to win two Nobel prizes? (Answer: Marie Curie)\n",
         "\n",
         "You will notice that keyword search performs very well with the simple query, and not so well with the hard one."
-      ],
-      "metadata": {
-        "id": "YtKPrTy7SLrG"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "njgAkvn5R7Vx"
+      },
+      "outputs": [],
       "source": [
         "# This function performs keyword search\n",
         "def keyword_search(query, results_lang='en', num_results=10):\n",
@@ -171,15 +162,15 @@
         "  )\n",
         "  result = response['data']['Get']['Articles']\n",
         "  return result"
-      ],
-      "metadata": {
-        "id": "njgAkvn5R7Vx"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "DmYe2CYJSNdF"
+      },
+      "outputs": [],
       "source": [
         "# This function prints the results nicely\n",
         "def print_result(result):\n",
@@ -189,20 +180,11 @@
         "      print(f\"\\033[4m{item['url']}\\033[0m\")\n",
         "      print(item['text'])\n",
         "      print()"
-      ],
-      "metadata": {
-        "id": "DmYe2CYJSNdF"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "simple_query = \"Who discovered penicillin?\"\n",
-        "keyword_search_results_simple = keyword_search(simple_query)\n",
-        "print_result(keyword_search_results_simple)"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -210,11 +192,10 @@
         "id": "0qoZVPO5SWrw",
         "outputId": "beea4cb3-3bd4-4716-8331-528bc76897bb"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "\u001b[95mPenicillin (2000) \u001b[0m\n",
             "\u001b[4mhttps://en.wikipedia.org/wiki?curid=23312\u001b[0m\n",
@@ -258,15 +239,16 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "simple_query = \"Who discovered penicillin?\"\n",
+        "keyword_search_results_simple = keyword_search(simple_query)\n",
+        "print_result(keyword_search_results_simple)"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "hard_query = \"Who was the first person to win two nobel prizes?\"\n",
-        "keyword_search_results_hard = keyword_search(hard_query)\n",
-        "print_result(keyword_search_results_hard)"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -274,11 +256,10 @@
         "id": "R29ttbW6Se_7",
         "outputId": "5a8ef067-2a29-44cf-9dee-5d6f9b39f289"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "\u001b[95mNeutrino (2000) \u001b[0m\n",
             "\u001b[4mhttps://en.wikipedia.org/wiki?curid=21485\u001b[0m\n",
@@ -322,23 +303,33 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "hard_query = \"Who was the first person to win two nobel prizes?\"\n",
+        "keyword_search_results_hard = keyword_search(hard_query)\n",
+        "print_result(keyword_search_results_hard)"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "Hm-a_fTZSktj"
+      },
       "source": [
         "# Dense Retrieval\n",
         "\n",
         "This section accompanies the [Dense Retrieval](https://cohere-enterprise.readme.io/docs/dense-retrieval) chapter of LLM University.\n",
         "\n",
         "Now we will use dense retrieval to search the answers for the two queries. Now you will notice that the results are good for both queries."
-      ],
-      "metadata": {
-        "id": "Hm-a_fTZSktj"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "VfgBUiFTShcR"
+      },
+      "outputs": [],
       "source": [
         "# This function performs dense retrieval\n",
         "def dense_retrieval(query, results_lang='en', num_results=10):\n",
@@ -378,21 +369,11 @@
         "    result = response['data']['Get']['Articles']\n",
         "\n",
         "    return result"
-      ],
-      "metadata": {
-        "id": "VfgBUiFTShcR"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "simple_query = \"Who discovered penicillin?\"\n",
-        "\n",
-        "dense_retrieval_results_simple = dense_retrieval(simple_query)\n",
-        "print_result(dense_retrieval_results_simple)"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -400,11 +381,10 @@
         "id": "TYs0NKxnTKM1",
         "outputId": "cea390ff-ffb0-43e3-bed1-cb1a182b248d"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "\u001b[95mAlexander Fleming (2000) \u001b[0m\n",
             "\u001b[4mhttps://en.wikipedia.org/wiki?curid=1937\u001b[0m\n",
@@ -448,15 +428,17 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "simple_query = \"Who discovered penicillin?\"\n",
+        "\n",
+        "dense_retrieval_results_simple = dense_retrieval(simple_query)\n",
+        "print_result(dense_retrieval_results_simple)"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "hard_query = \"Who was the first person to win two Nobel prizes?\"\n",
-        "dense_retrieval_results_hard = dense_retrieval(hard_query)\n",
-        "print_result(dense_retrieval_results_hard)"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -464,11 +446,10 @@
         "id": "QxRhQdX0Uq_y",
         "outputId": "38a71da5-6a00-4ed7-ecc7-3dad6619d987"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "\u001b[95mNobel Prize (2000) \u001b[0m\n",
             "\u001b[4mhttps://en.wikipedia.org/wiki?curid=21201\u001b[0m\n",
@@ -512,36 +493,37 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "hard_query = \"Who was the first person to win two Nobel prizes?\"\n",
+        "dense_retrieval_results_hard = dense_retrieval(hard_query)\n",
+        "print_result(dense_retrieval_results_hard)"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "kbeNQtzAMagI"
+      },
       "source": [
         "### Searching in other languages\n",
         "Changing the `results_lang` parameter to any of the following: en, de, fr, es, it, ja, ar, zh, ko, hi (the available languages in the demo) allows you to get results in any language you want. For example, here are the results to the hard query in Arabic."
-      ],
-      "metadata": {
-        "id": "kbeNQtzAMagI"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "arabic_results = dense_retrieval(hard_query, results_lang='ar')\n",
-        "print_result(spanish_results)"
-      ],
+      "execution_count": 42,
       "metadata": {
-        "id": "mkogocjILr6G",
-        "outputId": "29a2dbcf-dc5c-49b3-e1b2-b22c033d5a8d",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "mkogocjILr6G",
+        "outputId": "29a2dbcf-dc5c-49b3-e1b2-b22c033d5a8d"
       },
-      "execution_count": 42,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "\u001b[95mجائزة نوبل (1000) \u001b[0m\n",
             "\u001b[4mhttps://ar.wikipedia.org/wiki?curid=1979\u001b[0m\n",
@@ -585,36 +567,35 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "arabic_results = dense_retrieval(hard_query, results_lang='ar')\n",
+        "print_result(arabic_results)"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "The query can also be in any other language. Here are the French results to a query in Spanish."
-      ],
       "metadata": {
         "id": "AN5M-6SbNDBH"
-      }
+      },
+      "source": [
+        "The query can also be in any other language. Here are the French results to a query in Spanish."
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "spanish_query = \"Quien descubrio la penicilina?\"\n",
-        "french_results = dense_retrieval(spanish_query, results_lang='fr')\n",
-        "print_result(french_results)"
-      ],
+      "execution_count": 47,
       "metadata": {
-        "id": "6GAxMo3aNBXd",
-        "outputId": "1f276d1a-d82a-4d0d-f49c-ff9d07273509",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "6GAxMo3aNBXd",
+        "outputId": "1f276d1a-d82a-4d0d-f49c-ff9d07273509"
       },
-      "execution_count": 47,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "\u001b[95mPénicilline (1000) \u001b[0m\n",
             "\u001b[4mhttps://fr.wikipedia.org/wiki?curid=92634\u001b[0m\n",
@@ -658,23 +639,33 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "spanish_query = \"Quien descubrio la penicilina?\"\n",
+        "french_results = dense_retrieval(spanish_query, results_lang='fr')\n",
+        "print_result(french_results)"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "198gdzLDVM2P"
+      },
       "source": [
         "# ReRank\n",
         "\n",
         "This section accompanies the [Reranking](https://cohere-enterprise.readme.io/docs/reranking-2) chapter of LLM University.\n",
         "\n",
         "Rerank is a powerful method that will enhance any search model. In short, rerank takes a query and a set of responses (or documents), and will surface the ones that are the most relevant as answers to the query. We'll use Rerank to improve keyword search with the hard query."
-      ],
-      "metadata": {
-        "id": "198gdzLDVM2P"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Umxiz9V7WOQJ"
+      },
+      "outputs": [],
       "source": [
         "def rerank_responses(query, responses, num_responses=10):\n",
         "  reranked_responses = co.rerank(\n",
@@ -684,31 +675,23 @@
         "    top_n = num_responses,\n",
         "  )\n",
         "  return reranked_responses"
-      ],
-      "metadata": {
-        "id": "Umxiz9V7WOQJ"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "hard_query = \"Who was the first person to win two nobel prizes?\"\n",
-        "keyword_searches_to_improve = keyword_search(hard_query, num_results = 100)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "QmJwcAl0H1F6"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "hard_query = \"Who was the first person to win two nobel prizes?\"\n",
+        "keyword_searches_to_improve = keyword_search(hard_query, num_results = 100)"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "for r in keyword_searches_to_improve[:20]:\n",
-        "  print(r['title'], ':', r['text'])"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -716,11 +699,10 @@
         "id": "R-sAFqmIIwh2",
         "outputId": "73b0fc6d-9aff-46f2-95e5-131b6b0fee73"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Neutrino : In the 1960s, the now-famous Homestake experiment made the first measurement of the flux of electron neutrinos arriving from the core of the Sun and found a value that was between one third and one half the number predicted by the Standard Solar Model. This discrepancy, which became known as the solar neutrino problem, remained unresolved for some thirty years, while possible problems with both the experiment and the solar model were investigated, but none could be found. Eventually, it was realized that both were actually correct and that the discrepancy between them was due to neutrinos being more complex than was previously assumed. It was postulated that the three neutrinos had nonzero and slightly different masses, and could therefore oscillate into undetectable flavors on their flight to the Earth. This hypothesis was investigated by a new series of experiments, thereby opening a new major field of research that still continues. Eventual confirmation of the phenomenon of neutrino oscillation led to two Nobel prizes, to R. Davis, who conceived and led the Homestake experiment, and to A.B. McDonald, who led the SNO experiment, which could detect all of the neutrino flavors and found no deficit.\n",
             "Western culture : By the will of the Swedish inventor Alfred Nobel the Nobel Prizes were established in 1895. The prizes in Chemistry, Literature, Peace, Physics, and Physiology or Medicine were first awarded in 1901. The percentage of ethnically European Nobel prize winners during the first and second halves of the 20th century were respectively 98 and 94 percent.\n",
@@ -744,29 +726,26 @@
             "Christians : Christians have made noted contributions to a range of fields, including philosophy, science and technology, medicine, fine arts and architecture, politics, literatures, music, and business. According to \"100 Years of Nobel Prizes\" a review of the Nobel Prizes award between 1901 and 2000 reveals that (65.4%) of Nobel Prizes Laureates, have identified Christianity in its various forms as their religious preference.\n"
           ]
         }
+      ],
+      "source": [
+        "for r in keyword_searches_to_improve[:20]:\n",
+        "  print(r['title'], ':', r['text'])"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "reranked_keyword_responses = rerank_responses(hard_query, keyword_searches_to_improve, num_responses=100)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "thziTh7eKB0-"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "reranked_keyword_responses = rerank_responses(hard_query, keyword_searches_to_improve, num_responses=100)"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "for r in reranked_keyword_responses[:10]:\n",
-        "  print(\"Title:\", r.document['title'])\n",
-        "  print(\"URL:\", r.document['url'])\n",
-        "  print(\"Text:\", r.document['text'])\n",
-        "  print(\"Score:\",  r.relevance_score)\n",
-        "  print()"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -774,11 +753,10 @@
         "id": "Dan5Q43AKyMh",
         "outputId": "b54db122-7c96-4efe-d922-b699dfe6753f"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Title: Nobel Prize\n",
             "URL: https://en.wikipedia.org/wiki?curid=21201\n",
@@ -832,10 +810,21 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "for r in reranked_keyword_responses[:10]:\n",
+        "  print(\"Title:\", r.document['title'])\n",
+        "  print(\"URL:\", r.document['url'])\n",
+        "  print(\"Text:\", r.document['text'])\n",
+        "  print(\"Score:\",  r.relevance_score)\n",
+        "  print()"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "ZiKHq4eeXu0d"
+      },
       "source": [
         "# Generating responses\n",
         "\n",
@@ -844,55 +833,49 @@
         "Generative models are great at talking, but when it comes to answer questions with facts, they are prone to hallucinations. In other words, they can answer with the wrong answer. To prevent this, we first search for the documents that are relevant to the query (using dense retrieval, but we can use any method). We then feed them to the generative model, and instruct it to answer the question from the information from those documents.\n",
         "\n",
         "The query is \"How many people have won more than one Nobel prize?\". You will notice that the model generates wrong answers, but when combined with search, it'll generate the correct answers."
-      ],
-      "metadata": {
-        "id": "ZiKHq4eeXu0d"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "import cohere\n",
-        "co = cohere.Client(cohere_api_key)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "DBlD76x4WgqO"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "import cohere\n",
+        "co = cohere.Client(cohere_api_key)"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "query = \"How many people have won more than one Nobel prize?\""
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "LVOj-KJ1X0fl"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "query = \"How many people have won more than one Nobel prize?\""
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "D0HdGsq4YKI8"
+      },
+      "outputs": [],
       "source": [
         "prediction_without_search = co.generate(\n",
         "    prompt=query,\n",
         "    max_tokens=50,\n",
         "    num_generations=5,\n",
         "    )"
-      ],
-      "metadata": {
-        "id": "D0HdGsq4YKI8"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "for p in prediction_without_search:\n",
-        "  print(p.text)"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -900,11 +883,10 @@
         "id": "3YbNpIKygBck",
         "outputId": "15316bd2-dad3-4ace-804a-b64bb03a97b2"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             " There have been 24 Nobel Prize recipients who have won the prize more than once. Among them, John Bardeen has won the most Nobel Prizes, with four Nobel Prizes in Physics. Marie Curie has won the most Nobel Prizes among women, with the\n",
             " There have been 25 Nobel Prize recipients who have won more than one Nobel Prize. Of these, 14 are men and 11 are women. The most Nobel Prizes won by a single person is four, which was achieved by Marie Curie, who won the\n",
@@ -913,14 +895,15 @@
             " There are currently 13 people who have won more than one Nobel Prize. The most Nobel Prizes won by a single person is four, which is the case for Marie Curie. She won the Nobel Prize in Physics in 1903, in 1911, and in\n"
           ]
         }
+      ],
+      "source": [
+        "for p in prediction_without_search:\n",
+        "  print(p.text)"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "responses = dense_retrieval(query, num_results = 20)\n",
-        "print_result(responses)"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -928,11 +911,10 @@
         "id": "ezjlg35SYL0h",
         "outputId": "d0b988cb-691d-4992-a0c6-b21b09209b42"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "\u001b[95mNobel Peace Prize (2000) \u001b[0m\n",
             "\u001b[4mhttps://en.wikipedia.org/wiki?curid=26230922\u001b[0m\n",
@@ -1016,14 +998,15 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "responses = dense_retrieval(query, num_results = 20)\n",
+        "print_result(responses)"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "context = [r['text'] for r in responses]\n",
-        "context[:10]"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1031,10 +1014,8 @@
         "id": "3CNlHTXSYYRG",
         "outputId": "7031ede3-925f-47ac-997f-026a6e504f87"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "[', the Peace Prize has been awarded to 110 individuals and 27 organizations. 18 women have won the Nobel Peace Prize, more than any other Nobel Prize. Only two recipients have won multiple Prizes: the International Committee of the Red Cross has won three times (1917, 1944, and 1963) and the Office of the United Nations High Commissioner for Refugees has won twice (1954 and 1981). Lê Đức Thọ is the only person who refused to accept the Nobel Peace Prize.',\n",
@@ -1049,13 +1030,23 @@
               " 'In 2009, a record 205 nominations were received, but the record was broken again in 2010 with 237 nominations; in 2011, the record was broken once again with 241 nominations. The statutes of the Nobel Foundation do not allow information about nominations, considerations, or investigations relating to awarding the prize to be made public for at least 50 years after a prize has been awarded. Over time, many individuals have become known as \"Nobel Peace Prize Nominees\", but this designation has no official standing, and means only that one of the thousands of eligible nominators suggested the person\\'s name for consideration. Indeed, in 1939, Adolf Hitler received a satirical nomination from a member of the Swedish parliament, mocking the (serious but unsuccessful) nomination of Neville Chamberlain. Nominations from 1901 to 1967 have been released in a database.']"
             ]
           },
+          "execution_count": 143,
           "metadata": {},
-          "execution_count": 143
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "context = [r['text'] for r in responses]\n",
+        "context[:10]"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "HklTHYw1aVWU"
+      },
+      "outputs": [],
       "source": [
         "prompt = f\"\"\"\n",
         "Use the information provided below to answer the questions at the end. If the answer to the question is not contained in the provided information, say \"The answer is not in the context\".\n",
@@ -1065,34 +1056,26 @@
         "---\n",
         "Question: How many people have won more than one Nobel prize?\n",
         "\"\"\""
-      ],
-      "metadata": {
-        "id": "HklTHYw1aVWU"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "lloV1wYJaoBH"
+      },
+      "outputs": [],
       "source": [
         "prediction_with_search = co.generate(\n",
         "    prompt=prompt,\n",
         "    num_generations=5,\n",
         "    max_tokens=50,\n",
         "    )"
-      ],
-      "metadata": {
-        "id": "lloV1wYJaoBH"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "for p in prediction_with_search:\n",
-        "  print(p.text)"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1100,11 +1083,10 @@
         "id": "X2CsoHrabqoR",
         "outputId": "84151fe7-b5b9-40cd-9ab6-e8f4f48ed4d3"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             " The answer is Five people have received two Nobel Prizes.\n",
             " The answer is Five people have received two Nobel Prizes. Marie Curie received the Physics Prize in 1903 for her work on radioactivity and the Chemistry Prize in 1911 for the isolation of pure radium, making her the only person to be awarded a Nobel\n",
@@ -1113,16 +1095,34 @@
             " The answer is Five people have received two Nobel Prizes. Marie Curie received the Physics Prize in 1903 for her work on radioactivity and the Chemistry Prize in 1911 for the isolation of pure radium, making her the only person to be awarded a Nobel\n"
           ]
         }
+      ],
+      "source": [
+        "for p in prediction_with_search:\n",
+        "  print(p.text)"
       ]
     },
     {
       "cell_type": "code",
-      "source": [],
+      "execution_count": null,
       "metadata": {
         "id": "ceLHt9Gf7vu9"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": []
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
To see the changes in a formatted notebook and not in the notebook's sources (which are not easily parsed), you can access the PR in Github.dev: https://github.dev/cohere-ai/notebooks/pull/79/files (another way to access it would be by entering . from the Github PR page).

Obviously, what we wanted to print here was the arabic results retrieved just before:

<img width="1083" alt="image" src="https://github.com/cohere-ai/notebooks/assets/6030745/64022ddd-6c83-43b9-ae59-c0f150eba258">
