### PR TITLE
Update Cohere_Redis_Guide.ipynb

### DIFF
--- a/notebooks/Cohere_Redis_Guide.ipynb
+++ b/notebooks/Cohere_Redis_Guide.ipynb
@@ -141,6 +141,28 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# contruct the data payload to be uploaded to your index\n",
+    "data = [{\"url\": row['url'],\n",
+    "         \"title\": row['title'],\n",
+    "         \"text\": row['text'],\n",
+    "         \"wiki_id\": row['wiki_id'],\n",
+    "         \"paragraph_id\": row['paragraph_id'],\n",
+    "         \"id\":row['id'],\n",
+    "         \"views\":row['views'],\n",
+    "         \"langs\":row['langs'],\n",
+    "         \"embedding\":v}\n",
+    "        for row, v in zip(corpus, res)]\n",
+    "\n",
+    "# load the data into your index\n",
+    "index.load(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
The previous version was missing the index.load() operation, which is essential for inserting the data inside the Redis vector db. This commit updates the notebook with the missing code, as per the [original tutorial](https://docs.cohere.com/docs/redis-and-cohere).