### PR TITLE
RAG Guide: Include python-dotenv to load Cohere and Pinecone API keys from .env file

### DIFF
--- a/notebooks/guides/RAG_with_Chat_Embed_and_Rerank_via_Pinecone.ipynb
+++ b/notebooks/guides/RAG_with_Chat_Embed_and_Rerank_via_Pinecone.ipynb
@@ -76,61 +76,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "id": "5pLAhQmTOKiV",
       "metadata": {
         "id": "5pLAhQmTOKiV"
       },
       "outputs": [],
       "source": [
-        "! pip install cohere hnswlib unstructured -q"
+        "! pip install cohere hnswlib unstructured python-dotenv -q"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 2,
       "id": "f3a03a57",
       "metadata": {
         "id": "f3a03a57"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "import cohere\n",
         "from pinecone import Pinecone, PodSpec\n",
@@ -146,53 +109,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": 3,
       "id": "f0b1935e",
       "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "import cohere\n",
         "import os\n",
+        "import dotenv\n",
+        "\n",
+        "dotenv.load_dotenv()\n",
         "co = cohere.Client(os.getenv(\"COHERE_API_KEY\"))\n",
         "pc = Pinecone(\n",
-        "    api_key=os.environ.get(\"PINECONE_API_KEY\")\n",
+        "    api_key=os.getenv(\"PINECONE_API_KEY\")\n",
         ")\n"
       ]
     },


### PR DESCRIPTION
RAG Guide: Include python-dotenv to load Cohere and Pinecone API keys from .env file

Nice convenience function, don't need to acecpt if you don't like it


## Test Plan
Notebook runs if you define API keys in an .env file

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/cohere-ai/notebooks/pull/160).
* #162
* #161
* __->__ #160