### PR TITLE
RAG Guide: Comment out set_css logic that breaks for Jupyter notebooks

### DIFF
--- a/notebooks/guides/RAG_with_Chat_Embed_and_Rerank_via_Pinecone.ipynb
+++ b/notebooks/guides/RAG_with_Chat_Embed_and_Rerank_via_Pinecone.ipynb
@@ -76,61 +76,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "id": "5pLAhQmTOKiV",
       "metadata": {
         "id": "5pLAhQmTOKiV"
       },
       "outputs": [],
       "source": [
-        "! pip install cohere hnswlib unstructured -q"
+        "! pip install cohere hnswlib unstructured python-dotenv -q"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 2,
       "id": "f3a03a57",
       "metadata": {
         "id": "f3a03a57"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "import cohere\n",
         "from pinecone import Pinecone, PodSpec\n",
@@ -146,53 +109,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": 3,
       "id": "f0b1935e",
       "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "import cohere\n",
         "import os\n",
+        "import dotenv\n",
+        "\n",
+        "dotenv.load_dotenv()\n",
         "co = cohere.Client(os.getenv(\"COHERE_API_KEY\"))\n",
         "pc = Pinecone(\n",
-        "    api_key=os.environ.get(\"PINECONE_API_KEY\")\n",
+        "    api_key=os.getenv(\"PINECONE_API_KEY\")\n",
         ")\n"
       ]
     },

--- a/notebooks/guides/RAG_with_Chat_Embed_and_Rerank_via_Pinecone.ipynb
+++ b/notebooks/guides/RAG_with_Chat_Embed_and_Rerank_via_Pinecone.ipynb
@@ -127,46 +127,28 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 4,
       "id": "Dx1cncziCWBB",
       "metadata": {
         "cellView": "form",
         "id": "Dx1cncziCWBB"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
-        "#@title Enable text wrapping in Google Colab\n",
+        "# #@title Enable text wrapping in Google Colab\n",
+        "# Uncomment the code below for Google Colab\n",
         "\n",
-        "from IPython.display import HTML, display\n",
+        "# from IPython.display import HTML, display\n",
         "\n",
-        "def set_css():\n",
-        "  display(HTML('''\n",
-        "  <style>\n",
-        "    pre {\n",
-        "        white-space: pre-wrap;\n",
-        "    }\n",
-        "  </style>\n",
-        "  '''))\n",
-        "get_ipython().events.register('pre_run_cell', set_css)"
+        "# def set_css():\n",
+        "#   display(HTML('''\n",
+        "#   <style>\n",
+        "#     pre {\n",
+        "#         white-space: pre-wrap;\n",
+        "#     }\n",
+        "#   </style>\n",
+        "#   '''))\n",
+        "# get_ipython().events.register('pre_run_cell', set_css)"
       ]
     },
     {
@@ -183,7 +165,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 5,
       "id": "3dca4a88",
       "metadata": {
         "colab": {
@@ -193,44 +175,7 @@
         "id": "3dca4a88",
         "outputId": "b05da1ee-0456-4387-c232-a43e0ffed54c"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "raw_documents = [\n",
         "    {\n",
@@ -276,7 +221,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 113,
+      "execution_count": 6,
       "id": "7c33412c",
       "metadata": {
         "colab": {
@@ -286,44 +231,7 @@
         "id": "7c33412c",
         "outputId": "cf04f8ed-8000-4433-f976-2d37747f21e7"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "class Vectorstore:\n",
         "    \"\"\"\n",
@@ -477,7 +385,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 114,
+      "execution_count": 7,
       "id": "4643e630",
       "metadata": {
         "colab": {
@@ -488,42 +396,6 @@
         "outputId": "fe01fcb6-3574-4322-d8d0-57d37aad397d"
       },
       "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
         {
           "name": "stdout",
           "output_type": "stream",
@@ -578,7 +450,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 115,
+      "execution_count": 8,
       "id": "82617b91",
       "metadata": {
         "colab": {
@@ -589,42 +461,6 @@
         "outputId": "7f1f2bc8-8ed9-4190-bd6b-7af2d9dc1980"
       },
       "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <style>\n",
-              "    pre {\n",
-              "        white-space: pre-wrap;\n",
-              "    }\n",
-              "  </style>\n",
-              "  "
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
         {
           "data": {
             "text/plain": [


### PR DESCRIPTION
RAG Guide: Comment out set_css logic that breaks for Jupyter notebooks

I noticed that this was breaking for when I was running this in Jupyter notebooks. I also noticed we had comments in the notebook saying `# Uncomment for Google Colab to ...` so figured we could do the same here. If you don't like it, no worries

## Test Plan
Before it wasn't working, and we got these errors
```
Error in callback <function set_css at 0x33e33d260> (for pre_run_cell), with arguments args (<ExecutionInfo object at 33e35b110, raw_cell="raw_documents = [
    {
        "title": "Text Emb.." store_history=True silent=False shell_futures=True cell_id=vscode-notebook-cell:/Users/rossdancraig/Projects/cohere-notebooks/notebooks/guides/RAG_with_Chat_Embed_and_Rerank_via_Pinecone.ipynb#X13sZmlsZQ%3D%3D>,),kwargs {}:

```

```
{
	"name": "TypeError",
	"message": "set_css() takes 0 positional arguments but 1 was given",
	"stack": "---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
TypeError: set_css() takes 0 positional arguments but 1 was given"
}
```

Now it works!

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/cohere-ai/notebooks/pull/161).
* #162
* __->__ #161
* #160