### PR TITLE
Adding Cohere source attribution

### DIFF
--- a/notebooks/Embed_Jobs_Serverless_Pinecone_Semantic_Search.ipynb
+++ b/notebooks/Embed_Jobs_Serverless_Pinecone_Semantic_Search.ipynb
@@ -50,7 +50,10 @@
         "from pinecone import Pinecone\n",
         "\n",
         "co = cohere.Client('COHERE_API_KEY')\n",
-        "pc = Pinecone(api_key=('PINECONE_API_KEY'))"
+        "pc = Pinecone(\n",
+        "    api_key=\"PINECONE_API_KEY\", \n",
+        "    source_tag=\"cohere\"\n",
+        ")"
       ]
     },
     {


### PR DESCRIPTION
Pinecone has asked us to add source attribution in our guides so they can track usage through the guide.