### PR TITLE
Notebook update: Creating_a_QA_bot_from_technical_documentation

### DIFF
--- a/notebooks/guides/Creating_a_QA_bot_from_technical_documentation.ipynb
+++ b/notebooks/guides/Creating_a_QA_bot_from_technical_documentation.ipynb
@@ -1,21 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "d5-gWUEqG4-T"
+      },
       "source": [
         "# Creating a QA bot from technical documentation\n",
         "\n",
@@ -24,23 +13,20 @@
         "We use the `aws-documentation` dataset ([link](https://github.com/siagholami/aws-documentation/tree/main)) for representativeness. This dataset contains 26k+ AWS documentation pages, preprocessed into 120k+ chunks, and 100 questions based on real user questions.\n",
         "\n",
         "We proceed as follows:\n",
-        "1. Embed the AWS documentation into a vector database using Cohere embeddings and `llama_index`\n",
+        "1. Embed the AWS documentation into a vector database using Cohere's `embed` model and `llama_index`\n",
         "2. Build a retriever using Cohere's `rerank` for better accuracy, lower inference costs and lower latency\n",
-        "3. Create model answers for the eval set of 100 questions\n",
-        "4. Evaluate the model answers against the golden answers of the eval set\n"
-      ],
-      "metadata": {
-        "id": "d5-gWUEqG4-T"
-      }
+        "3. Create model answers for the eval set of 100 questions using Cohere's `command-r` model\n",
+        "4. Evaluate the generated answers against the golden answers of the eval set using `command-r+`, Cohere's most capable generative model as a judge\n"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## Setup"
-      ],
       "metadata": {
         "id": "JY2wHt3AG7X0"
-      }
+      },
+      "source": [
+        "## Setup"
+      ]
     },
     {
       "cell_type": "code",
@@ -56,7 +42,32 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "kJ_9dyJxG0zA"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/Users/neel/Library/Caches/pypoetry/virtualenvs/notebooks-WcB_wkWy-py3.11/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+            "  from .autonotebook import tqdm as notebook_tqdm\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "True"
+            ]
+          },
+          "execution_count": 1,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
+        "import os\n",
         "import cohere\n",
         "import datasets\n",
         "from llama_index.core import StorageContext, VectorStoreIndex, load_index_from_storage\n",
@@ -67,29 +78,33 @@
         "import json\n",
         "from pathlib import Path\n",
         "from tqdm import tqdm\n",
-        "from typing import List\n"
-      ],
-      "metadata": {
-        "id": "kJ_9dyJxG0zA"
-      },
-      "execution_count": null,
-      "outputs": []
+        "from typing import List\n",
+        "\n",
+        "from dotenv import load_dotenv\n",
+        "load_dotenv()\n"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# Set up Cohere client\n",
-        "api_key = \"\" # <your API key>\n",
-        "co = cohere.Client(api_key=api_key)"
-      ],
+      "execution_count": 18,
       "metadata": {
         "id": "EECuI7OdIy8M"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "# Set up Cohere client\n",
+        "# TODO: delete before push\n",
+        "api_key = os.getenv(\"COHERE_API_KEY\") # <your API key>\n",
+        "co = cohere.Client(api_key=api_key, log_warning_experimental_features=False)\n",
+        "\n",
+        "stub_len = len(\"https://github.com/siagholami/aws-documentation/tree/main/documents/\")"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "u_UfRVoBIHmD"
+      },
       "source": [
         "## 1. Embed technical documentation and store as vector database\n",
         "\n",
@@ -98,24 +113,12 @@
         "* Store inside a vector database, `VectorStoreIndex` from LlamaIndex\n",
         "\n",
         "\n",
-        "Because this process is lengthy (~2h for all documents on a MacBookPro), we store the index to disc for future reuse. We also provide a (commented) code snippet to index only a subset of the data. If you use this snippet, bear in mind that many documents will become unavailable to the model and, as a result, performance will suffer!"
-      ],
-      "metadata": {
-        "id": "u_UfRVoBIHmD"
-      }
+        "Because this process is lengthy (~2h for all documents on a MacBookPro), we store the index to disc for future reuse. We also provide an option to to index only a subset of the data. This can be enabled by setting the value of the variable `USE_SNIPPET` to `True` in the block below. If you use this option, bear in mind that many documents will become unavailable to the model and, as a result, performance will suffer!"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "data = datasets.load_dataset(\"sauravjoshi23/aws-documentation-chunked\")\n",
-        "print(data)\n",
-        "# The data comes prechunked. We keep the data as-is in this notebook.\n",
-        "# For more information on optimal preprocessing strategies, please check\n",
-        "# our other notebooks!\n",
-        "\n",
-        "# Build a mapping from sample id to index inside data (will be useful for retrieval later)\n",
-        "map_id2index = {sample[\"id\"]: index for index, sample in enumerate(data[\"train\"])}\n"
-      ],
+      "execution_count": 5,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -123,36 +126,83 @@
         "id": "NoXezqvoG02f",
         "outputId": "cabfccf3-3c15-4955-dab9-e2734fa65a7d"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_token.py:88: UserWarning: \n",
-            "The secret `HF_TOKEN` does not exist in your Colab secrets.\n",
-            "To authenticate with the Hugging Face Hub, create a token in your settings tab (https://huggingface.co/settings/tokens), set it as secret in your Google Colab and restart your session.\n",
-            "You will be able to reuse this secret in all of your notebooks.\n",
-            "Please note that authentication is recommended but still optional to access public models or datasets.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
-            "DatasetDict({\n",
-            "    train: Dataset({\n",
-            "        features: ['id', 'text', 'source'],\n",
-            "        num_rows: 187147\n",
-            "    })\n",
+            "Dataset({\n",
+            "    features: ['id', 'text', 'source', 'short_source'],\n",
+            "    num_rows: 187147\n",
             "})\n"
           ]
         }
+      ],
+      "source": [
+        "# Set to true if you want to use only a small sample of the training data (~5000) rows\n",
+        "USE_SNIPPET = True\n",
+        "\n",
+        "data = datasets.load_dataset(\"sauravjoshi23/aws-documentation-chunked\")\n",
+        "# The data comes prechunked. We keep the data as-is in this notebook.\n",
+        "# For more information on optimal preprocessing strategies, please check\n",
+        "# our other notebooks!\n",
+        "\n",
+        "# Add a column with the shortened source. This will be used to cross-reference with the QA Evaluation dataset to ensure\n",
+        "# that the relevant testing data sources are captured in the smaller samples of data selected\n",
+        "if USE_SNIPPET:\n",
+        "    data = data.map(lambda x: {\"short_source\": x[\"source\"][stub_len:].replace(\"/doc_source\", \"\")})\n",
+        "\n",
+        "# Build a mapping from sample id to index inside data (will be useful for retrieval later)\n",
+        "map_id2index = {sample[\"id\"]: index for index, sample in enumerate(data[\"train\"])}\n",
+        "\n",
+        "print(data[\"train\"])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "To assess the performance of our RAG pipeline, we will also need some QA pairs to validate the answers generated by `command`. The author of the repository above provides 100 QA pairs that we can test the model on. Let's download these questions.\n",
+        "\n",
+        "**NOTE**: if you have set `USE_SNIPPET` to `True`, the following block also creates a separate copy of the dataset with documents that the QA pairs test on, so that we can ensure that these particular documents are always included as a subset in the smaller sampled training set."
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Filter: 100%|██████████| 187147/187147 [00:00<00:00, 404111.70 examples/s]\n"
+          ]
+        }
+      ],
+      "source": [
+        "# -- to fix SSL error -- \n",
+        "import ssl\n",
+        "ssl._create_default_https_context = ssl._create_unverified_context\n",
+        "\n",
+        "# Load data from github\n",
+        "url = \"https://github.com/siagholami/aws-documentation/blob/main/QA_true.csv?raw=true\"\n",
+        "qa_pairs = pd.read_csv(url)\n",
+        "\n",
+        "# Filters and extracts the rows in the data that correspond with documents that are referenced\n",
+        "# in the QA pairs test set\n",
+        "if USE_SNIPPET:\n",
+        "    golden_docs = qa_pairs['Document_True'].tolist()\n",
+        "    golden_doc_data = data.filter(lambda x: x['short_source'] in golden_docs)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "id": "tvgtKDBTG05h"
+      },
+      "outputs": [],
       "source": [
         "# Create index in vector database, and persist it for later reuse\n",
         "# Note: this cell takes about ~2h on a MacBookPro\n",
@@ -165,39 +215,50 @@
         "    cohere_api_key=api_key,\n",
         "    model_name=\"embed-english-v3.0\",\n",
         ")\n",
-        "\n",
+        " \n",
         "if not path_index.exists() or overwrite:\n",
         "    # Documents are prechunked. Keep them as-is for now\n",
-        "    stub_len = len(\"https://github.com/siagholami/aws-documentation/tree/main/documents/\")\n",
         "    documents = [\n",
         "        # -- for indexing full dataset --\n",
-        "        TextNode(\n",
-        "            text=sample[\"text\"],\n",
-        "            title=sample[\"source\"][stub_len:], # save source minus stub\n",
-        "            id_=sample[\"id\"],\n",
-        "        ) for sample in data[\"train\"]\n",
-        "        # -- for testing on subset --\n",
         "        # TextNode(\n",
-        "        #     text=data[\"train\"][index][\"text\"],\n",
-        "        #     title=data[\"train\"][index][\"source\"][stub_len:],\n",
-        "        #     id_=data[\"train\"][index][\"id\"],\n",
-        "        # ) for index in range(1_000)\n",
+        "        #     text=sample[\"text\"],\n",
+        "        #     title=sample[\"source\"][stub_len:], # save source minus stub\n",
+        "        #     id_=sample[\"id\"],\n",
+        "        # ) for sample in data[\"train\"]\n",
+        "        # -- for testing on subset --\n",
+        "        TextNode(\n",
+        "            text=data[\"train\"][index][\"text\"],\n",
+        "            title=data[\"train\"][index][\"source\"][stub_len:],\n",
+        "            id_=data[\"train\"][index][\"id\"],\n",
+        "        ) for index in range(5_000)\n",
         "    ]\n",
+        "\n",
+        "    # extend the sample of documents with the documents referenced in the QA pairs\n",
+        "    # test set\n",
+        "    if USE_SNIPPET:\n",
+        "        documents.extend(\n",
+        "            [\n",
+        "                TextNode(\n",
+        "                    text=data[\"text\"],\n",
+        "                    title=data[\"source\"][stub_len:],\n",
+        "                    id_=data[\"id\"],\n",
+        "                ) for data in golden_doc_data[\"train\"]\n",
+        "            ]\n",
+        "        )\n",
+        "\n",
         "    index = VectorStoreIndex(documents, embed_model=embed_model)\n",
         "    index.storage_context.persist(path_index)\n",
         "\n",
         "else:\n",
         "    storage_context = StorageContext.from_defaults(persist_dir=path_index)\n",
         "    index = load_index_from_storage(storage_context, embed_model=embed_model)\n"
-      ],
-      "metadata": {
-        "id": "tvgtKDBTG05h"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "sS2yzRwOKHTv"
+      },
       "source": [
         "## 2. Build a retriever using Cohere's `rerank`\n",
         "\n",
@@ -208,13 +269,15 @@
         "```\n",
         "\n",
         "We recently released [Rerank-3](https://txt.cohere.com/rerank-3/) (April '24), which we can use to improve the quality of retrieval, as well as reduce latency and the cost of inference. To use the retriever with `rerank`, we create a thin wrapper around `index.as_retriever` as follows:"
-      ],
-      "metadata": {
-        "id": "sS2yzRwOKHTv"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "id": "Wy_BGGbGG08w"
+      },
+      "outputs": [],
       "source": [
         "class RetrieverWithRerank:\n",
         "    def __init__(self, retriever, api_key):\n",
@@ -246,15 +309,27 @@
         "    index.as_retriever(similarity_top_k=top_k),\n",
         "    api_key=api_key,\n",
         ")\n"
-      ],
-      "metadata": {
-        "id": "Wy_BGGbGG08w"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "ODihI1YCG0_5"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Deleting an Auto Scaling group will stop and terminate all of your Amazon EC2 instances within that group. \n",
+            "\n",
+            "However, you may want to instead stop or terminate your Amazon EC2 instances individually, especially if you no longer need them running. This can be done using alarm actions in CloudWatch.\n",
+            "\n",
+            "If you want to remove an Auto Scaling group but keep your instances, you can follow the removal process described in the Amazon EC2 User Guide.\n"
+          ]
+        }
+      ],
       "source": [
         "# Test the retriever on a single question!\n",
         "query = \"What happens to my Amazon EC2 instances if I delete my Auto Scaling group?\"\n",
@@ -265,24 +340,36 @@
         "# Call Cohere's RAG pipeline with co.chat and the `documents` argument\n",
         "resp = co.chat(message=query, model=\"command-r\", temperature=0., documents=documents)\n",
         "print(resp.text)\n"
-      ],
-      "metadata": {
-        "id": "ODihI1YCG0_5"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "This works! With `co.chat`, you get the additional benefit that citations are returned for every span of text. Here's a simple function to display the citations inside square brackets."
-      ],
       "metadata": {
         "id": "tHTKtvMTMLhz"
-      }
+      },
+      "source": [
+        "This works! With `co.chat`, you get the additional benefit that citations are returned for every span of text. Here's a simple function to display the citations inside square brackets."
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "id": "7fH5mv2PG1DI"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Deleting an Auto Scaling group will stop and terminate [14]  all of your Amazon EC2 instances [14]  within that group. [14]  \n",
+            "\n",
+            "However, you may want to instead stop or terminate your Amazon EC2 instances individually [6] , especially if you no longer need them running. [6]  This can be done using alarm actions in CloudWatch. [6] \n",
+            "\n",
+            "If you want to remove an Auto Scaling group but keep your instances [18] , you can follow the removal process described in the Amazon EC2 User Guide. [18] \n"
+          ]
+        }
+      ],
       "source": [
         "def build_answer_with_citations(response):\n",
         "    \"\"\" \"\"\"\n",
@@ -307,86 +394,73 @@
         "\n",
         "grounded_answer = build_answer_with_citations(resp)\n",
         "print(grounded_answer)\n"
-      ],
-      "metadata": {
-        "id": "7fH5mv2PG1DI"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "f1mJdBQYRI4k"
+      },
       "source": [
         "## 3. Create model answers for 100 QA pairs\n",
         "\n",
         "Now that we have a running pipeline, we need to assess its performance.\n",
         "\n",
-        "The author of the repository provides 100 QA pairs that we can test the model on. Let's download these questions, then run inference on all 100 questions. Later, we will use Command-R+ -- Cohere's largest and most powerful model -- to measure performance."
-      ],
-      "metadata": {
-        "id": "f1mJdBQYRI4k"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Load data from github\n",
-        "url = \"https://github.com/siagholami/aws-documentation/blob/main/QA_true.csv?raw=true\"\n",
-        "qa_pairs = pd.read_csv(url)\n",
-        "qa_pairs.sample(2)\n"
-      ],
-      "metadata": {
-        "id": "jWkBVKSvMlip"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
+        "We can now run inference on all of the QA test pairs (100 questions). Later, we will use Command-R+ -- Cohere's largest and most powerful model -- to measure performance.\n",
+        "\n",
         "We'll use the fields as follows:\n",
         "* `Question`: the user question, passed to `co.chat` to generate the answer\n",
         "* `Answer_True`: treat as the ground gruth; compare to the model-generated answer to determine its correctness\n",
-        "* `Document_True`: treat as the (single) golden document; check the rank of this document inside the model's retrieved documents"
-      ],
-      "metadata": {
-        "id": "eS_IDKnvcI40"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
+        "* `Document_True`: treat as the (single) golden document; check the rank of this document inside the model's retrieved documents\n",
+        "\n",
         "We'll loop over each question and generate our model answer. We'll also complete two steps that will be useful for evaluating our model next:\n",
         "1. We compute the rank of the golden document amid the retrieved documents -- this will inform how well our retrieval system performs\n",
         "2. We prepare the grading prompts -- these will be sent to an LLM scorer to compute the goodness of responses"
-      ],
-      "metadata": {
-        "id": "bi4gH235eMzA"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "id": "rR67DcP5epAV"
+      },
+      "outputs": [],
       "source": [
         "# Define the LLM eval prompt\n",
         "# We request a score and a reason for assigning that score to 'trigger CoT' and\n",
         "# improve the model response\n",
         "\n",
-        "LLM_EVAL_TEMPLATE = \"\"\"## References\n",
+        "LLM_EVAL_TEMPLATE = \\\n",
+        "\"\"\"\n",
+        "## References\n",
         "{references}\n",
         "\n",
         "QUESTION: based on the above reference documents, answer the following question: {question}\n",
         "ANSWER: {answer}\n",
         "STUDENT RESPONSE: {completion}\n",
         "\n",
-        "Based on the question and answer above, grade the studen't reponse. A correct response will contain exactly \\\n",
+        "Based on the question (QUESTION) and answer above (ANSWER), grade the student's reponse (STUDENT RESPONSE). A correct response will contain exactly \\\n",
         "the same information as in the answer, even if it is worded differently. If the student's reponse is correct, \\\n",
         "give it a score of 1. Otherwise, give it a score of 0. Let's think step by step. Return your answer as \\\n",
         "as a compilable JSON with the following structure:\n",
         "{{\n",
         "    \"reasoning\": <reasoning>,\n",
         "    \"score: <score of 0 or 1>,\n",
-        "}}\"\"\"\n",
-        "\n",
+        "}}\n",
+        "\"\"\"\n",
+        "# Response format to enforce the model to produce a JSONic structure with its response\n",
+        "# as instructed by the eval prompt above\n",
+        "RESPONSE_FORMAT = {\n",
+        "    \"type\": \"json_object\",\n",
+        "    \"schema\": {\n",
+        "        \"type\": \"object\",\n",
+        "        \"required\": [\"reasoning\", \"score\"],\n",
+        "        \"properties\": {\n",
+        "            \"reasoning\": { \"type\": \"string\" },\n",
+        "            \"score\": { \"type\": \"integer\"}\n",
+        "        }\n",
+        "    }\n",
+        "}\n",
         "\n",
         "def get_rank_of_golden_within_retrieved(golden: str, retrieved: List[dict]) -> int:\n",
         "    \"\"\"\n",
@@ -404,20 +478,29 @@
         "        # format as in dataset\n",
         "        source = source[stub_len:]  # remove stub\n",
         "        source = source.replace(\"/doc_source\", \"\")  # remove /doc_source/\n",
+        "        \n",
         "        if source not in doc_to_rank:\n",
         "            doc_to_rank[source] = rank + 1\n",
         "\n",
         "    # Return rank of `golden`, defaulting to len(retrieved) + 1 if it's absent\n",
         "    return doc_to_rank.get(golden, len(retrieved) + 1)\n"
-      ],
-      "metadata": {
-        "id": "rR67DcP5epAV"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "id": "tAg3MTOcMll4"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "100%|██████████| 100/100 [09:19<00:00,  5.59s/it]\n"
+          ]
+        }
+      ],
       "source": [
         "from tqdm import tqdm\n",
         "\n",
@@ -432,7 +515,12 @@
         "\n",
         "    # --- Produce answer using retriever ---\n",
         "    documents = retriever.retrieve(query, top_n=top_n)\n",
-        "    resp = co.chat(message=query, model=\"command-r\", temperature=0., documents=documents)\n",
+        "    resp = co.chat(\n",
+        "        message=query,\n",
+        "        model=\"command-r\",\n",
+        "        temperature=0,\n",
+        "        documents=documents,\n",
+        "    )\n",
         "    answer = resp.text\n",
         "    answers.append(answer)\n",
         "\n",
@@ -447,18 +535,29 @@
         "    # ^ snippet looks complicated, but all it does it unpack all kwargs from `documents`\n",
         "    # into text separated by \\n\\n\n",
         "    grading_prompt = LLM_EVAL_TEMPLATE.format(\n",
-        "        references=references_text, question=query, answer=golden_answer, completion=answer,\n",
+        "        references=references_text, question=query, answer=golden_answer, completion=answer\n",
         "    )\n",
         "    grading_prompts.append(grading_prompt)\n"
-      ],
-      "metadata": {
-        "id": "tAg3MTOcMll4"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import pickle\n",
+        "\n",
+        "# Optional, to persist the grading_prompts list as a pickle object\n",
+        "with open(\"../data/grading_prompts.pkl\", \"wb\") as f:\n",
+        "    pickle.dump(grading_prompts, f)"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "2BCs7ozyO1vL"
+      },
       "source": [
         "## 4. Evaluate model performance\n",
         "\n",
@@ -467,108 +566,171 @@
         "2. How good is the retrieval? We'll use the rank of the golden document within the retrieved documents to this end.\n",
         "\n",
         "Note that this pipeline is for illustration only. To measure performance in practice, we would want to run more in-depths tests on a broader, representative dataset."
-      ],
-      "metadata": {
-        "id": "2BCs7ozyO1vL"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "id": "1qBvMpYmQDTK"
+      },
+      "outputs": [],
       "source": [
         "# For simplicity, prepare a DataFrame with the results\n",
         "results = pd.DataFrame()\n",
         "results[\"answer\"] = answers\n",
         "results[\"golden_answer\"] = qa_pairs[\"Answer_True\"]\n",
         "results[\"rank\"] = ranks\n"
-      ],
-      "metadata": {
-        "id": "1qBvMpYmQDTK"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "8Wglx0dsQtgX"
+      },
       "source": [
         "### 4.1 Compare answer to golden answer\n",
         "\n",
         "We'll use Command-R+ as a judge of whether the answers produced by our model convey the same information as the golden answers. Since we've defined the grading prompts earlier, we can simply ask our LLM judge to evaluate that grading prompt. After a little bit of postprocessing, we can then extract our model scores."
-      ],
-      "metadata": {
-        "id": "8Wglx0dsQtgX"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 40,
+      "metadata": {
+        "id": "_F3V4E56Q1CE"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "100%|██████████| 100/100 [06:41<00:00,  4.02s/it]\n"
+          ]
+        }
+      ],
       "source": [
+        "import pickle\n",
+        "\n",
         "scores = []\n",
         "reasonings = []\n",
         "\n",
         "def remove_backticks(text: str) -> str:\n",
-        "  \"\"\"\n",
-        "  Some models are trained to output JSON in Markdown formatting:\n",
-        "  ```json {json object}```\n",
-        "  Remove the backticks from those model responses so that they become\n",
-        "  parasable by json.loads.\n",
-        "  \"\"\"\n",
-        "  if text.startswith(\"```json\"):\n",
-        "      text = text[7:]\n",
-        "  if text.endswith(\"```\"):\n",
-        "      text = text[:-3]\n",
-        "  return text\n",
+        "    \"\"\"\n",
+        "    Some models are trained to output JSON in Markdown formatting:\n",
+        "    ```json {json object}```\n",
+        "    Remove the backticks from those model responses so that they become\n",
+        "    parasable by json.loads.\n",
+        "    \"\"\"\n",
+        "    if text.startswith(\"```json\"):\n",
+        "        text = text[7:]\n",
+        "    if text.endswith(\"```\"):\n",
+        "        text = text[:-3]\n",
+        "    return text\n",
         "\n",
+        "\n",
+        "# -- uncomment to load saved grading_prompts list --\n",
+        "with open(\"../data/grading_prompts.pkl\", \"rb\") as f:\n",
+        "    grading_prompts = pickle.load(f)\n",
         "\n",
         "for prompt in tqdm(grading_prompts, total=len(grading_prompts)):\n",
-        "  resp = co.chat(message=prompt, model=\"command-r-plus\", temperature=0.)\n",
-        "  # Convert response to JSON to extract the `score` and `reasoning` fields\n",
-        "  # We remove backticks for compatibility with different LLMs\n",
-        "  parsed = json.loads(remove_backticks(resp.text))\n",
-        "  scores.append(parsed[\"score\"])\n",
-        "  reasonings.append(parsed[\"reasoning\"])\n"
-      ],
-      "metadata": {
-        "id": "_F3V4E56Q1CE"
-      },
-      "execution_count": null,
-      "outputs": []
+        "    resp = co.chat(\n",
+        "       message=prompt, \n",
+        "       model=\"command-r-plus\", \n",
+        "       temperature=0., \n",
+        "       response_format=RESPONSE_FORMAT,\n",
+        "    )\n",
+        "    # Convert response to JSON to extract the `score` and `reasoning` fields\n",
+        "    # We remove backticks for compatibility with different LLMs\n",
+        "    parsed = json.loads(resp.text)\n",
+        "    scores.append(parsed[\"score\"])\n",
+        "    reasonings.append(parsed[\"reasoning\"])\n"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {},
+      "outputs": [],
       "source": [
-        "# Add scores to our DataFrame\n",
-        "results[\"score\"] = scores\n",
-        "results[\"reasoning\"] = reasonings"
-      ],
+        "import pickle\n",
+        "\n",
+        "# Optional, to persist scores and reasonings lists\n",
+        "with open(\"../data/scores.pkl\", \"wb\") as f:\n",
+        "    pickle.dump(scores, f)\n",
+        "with open(\"../data/reasonings.pkl\", \"wb\") as f:\n",
+        "    pickle.dump(reasonings, f)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
       "metadata": {
         "id": "1xksywOeQ1IJ"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "import pickle\n",
+        "\n",
+        "# -- uncomment to load saved scores, reasonings lists --\n",
+        "with open(\"../data/scores.pkl\", \"rb\") as f:\n",
+        "   scores = pickle.load(f)\n",
+        "with open(\"../data/reasonings.pkl\", \"rb\") as f:\n",
+        "   reasonings = pickle.load(f)\n",
+        "\n",
+        "# Add scores to our DataFrame\n",
+        "results[\"score\"] = scores\n",
+        "results[\"reasoning\"] = reasonings"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "print(f\"Average score: {results['score'].mean():.3f}\")\n"
-      ],
+      "execution_count": 22,
       "metadata": {
         "id": "l8Z2w1ERSeHZ"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Average score: 0.980\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(f\"Average score: {results['score'].mean():.3f}\")\n"
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "ob-Km6dAPeHJ"
+      },
       "source": [
         "### 4.2 Compute rank\n",
         "\n",
-        "We've already computed the rank of the golden documents using `get_rank_of_golden_within_retrieved`. Here, we'll plot the histogram of ranks, using blue when the answer scored a 1, and red when the answer scored a 0."
-      ],
-      "metadata": {
-        "id": "ob-Km6dAPeHJ"
-      }
+        "We've already computed the rank of the golden documents using `get_rank_of_golden_within_retrieved`. Here, we'll plot the histogram of ranks, using blue when the answer scored a 1"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 39,
+      "metadata": {
+        "id": "SLn3s3n_MlpO"
+      },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgsAAAE/CAYAAADIXIDoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/TGe4hAAAACXBIWXMAAA9hAAAPYQGoP6dpAABPtklEQVR4nO3dd1gU18IG8Hd3WbooRcREEyNxaQICghUEjS1RE9QUFYy9a9QYezQWDMaGYsWGvdeoidFr7FjAkvjZS1RUVBBBFCm75/uDy1xXcAVcXCTv73l8cGdnzpw5e2b23TMzuzIhhAARERHRK8gNXQEiIiIq2RgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0Ylggegm/p4zo3VTc++6/+dhQqLAQGhoKJycnrX/Ozs7w9vZG69atsW3btmKpZGRkJJycnIql7J07dyIoKAjVq1fHmDFjimUduYYPH46GDRvqnGfz5s1wcnJCfHx8sdZFl4YNG2L48OEGW78hxcXFoUePHgWaNz4+HkFBQXj06FEx14qKS2hoKEJDQ3XOU5zHn4JycnJCZGSkQetQ0jg5OUnHqYSEBPTo0QN37twplnWlpqZi6NChiI2N1TlffHw8nJycsHnz5mKpR1G82HeSk5MRGBiI27dvF7oco8Iu4OrqirFjx0qP1Wo1EhISEB0djaFDh6JcuXJo0KBBoStiKOPHj0eVKlUQHh6OChUqGLo6ZGAbNmzAtWvXXjufEAIjRozAt99+Cxsbm7dQMyJ6mUwmAwAcPXoUBw4cKLb1XLhwAdu2bUObNm10zmdvb49169bhgw8+KLa6vAlra2t06tQJI0eOxPLly6X2K4hChwVLS0vUqFEjz/SAgADUqVMHmzdvfqfCwuPHj1GvXj3UqlXL0FWhd8iePXtw+fJlLF682NBVIfpXKl++POzt7Q1dDS3Gxsb5vj+WJO3bt8e8efOwZ88eNGnSpMDL6e2aBRMTExgbG2sllUePHmHcuHHSML+fnx/69u2rNcQeGhqKUaNGISoqCoGBgXB3d8c333yDv/7665Xrunv3LgIDA9G6dWukpqa+cr6///4bXbt2Ra1ateDt7Y1evXrhypUrAIDjx49LQ4tz5szROfSflpaGMWPGoE6dOvDy8sKgQYMQHR2dZ2hy165daN26Nby8vFCvXj2MGTMGKSkpr6yfRqPB3LlzERgYCE9PT/Tp0yff+S9fvoyePXvC29sb3t7e6Nu3r9YwUu62xMTEoEuXLvD09ES9evUwZcoUqNXqV64fAC5evIjOnTvDy8sLQUFB2L59e555MjIyMGfOHDRr1gzu7u5o0qQJoqKioNFotObbunUrgoOD4enpicDAQEybNg2ZmZkA8j8F8/KQ3YvbERoaCg8PDwQGBmLDhg148OAB+vXrBy8vLzRo0ADR0dFaZT1+/BhjxoxB3bp14e7ujq+++goxMTFa8zg5OWHVqlUYNWoU/Pz84OXlhe+++w6JiYlSHbds2YI7d+68dihxwYIFaNq0KYyNjbXKX7NmDYYPHw4fHx/4+flh4sSJeP78OSZPnozatWujVq1aGDVqFDIyMqTlXrefnDt3Dm5ublqnhpKSklCnTh107tz5ledRQ0NDMWbMGMydOxf+/v7w9PRE9+7dkZiYiE2bNqFx48bw8vJCp06d8vT9vXv3onXr1nB3d0e9evUwceJEPHv2LM887du3h5eXF6pXr45mzZph1apV0vMF7ZdHjhzBV199BS8vL/j6+qJ3796vHd158OABBg0aBD8/P/j6+mLMmDGYMWOGVh9Tq9VYtWoVWrZsKfWlqVOnarX9yzIyMvDzzz+jXr168PLywogRI/KdPzY2FiEhIfD09ISfnx+GDRumdTpq8+bNcHV1xdmzZ/H111/D3d0dQUFBBQqXJ06cwNdffw1PT080bdoUR48ezTPPkydP8PPPP+OTTz6Bu7s7WrRogY0bN2rNI4RAdHQ0mjdvDg8PDzRu3BiLFy8u8Hn3//znP3BycsL58+elaVu3boWTkxM2bNggTbtw4QKcnJxw+vRpAMDJkyfRtWtX+Pr6onr16mjYsCEiIyO1jhc7duxAq1at4OHhgdq1a2PIkCG4f/++9HzDhg0xa9YsTJ48GXXr1oWHhwe6du2Kf/75R5pHpVJJ++mIESMAAI0aNXrlKdTc/rh27VoEBQXB29sbR44cAaD79Tx+/Dg6duwIAOjYsaN02io0NBRDhgzBgAEDUKNGDXTu3Dnf0xB3797F4MGD4efnB09PT3z77bdabdq0aVMMGDAgT30///xz9O7dW3pckH2yIH3H2NgYTZs2xYIFC/Jtp1cShRASEiI6dOggsrKypH/Pnz8X165dE4MHDxYqlUrs27dPCCGERqMRbdu2FY0bNxY7duwQx44dE8uWLRNeXl6iS5cuWmX6+PiIr776SuzZs0f88ccfolGjRiIgIEBkZ2cLIYSYNWuWUKlUQgghHjx4IBo3biw+//xz8fjx41fWNSYmRri5uYkuXbqIvXv3ip07d4pWrVoJb29vcfXqVfHkyRNx+vRpoVKpxMiRI8Xp06dFRkZGvmWFhoaKmjVrilWrVok///xTdO/eXVSvXl2qkxBCzJkzRzg5OYlx48aJgwcPilWrVgk/Pz/RsmVLkZ6eLoQQYtiwYSIoKEhaJjw8XLi6uorIyEhx8OBBMWLECOHm5iZUKpW4ffu2EEKI69evCy8vL9GmTRvxxx9/iF27domWLVuKevXqicTERCGEEMeOHRMqlUrUrVtXzJ49Wxw9elRMmjRJqFQqsWbNmle2UUJCgvDx8RFt2rQRe/bsEVu2bBH+/v7C1dVVDBs2THodO3XqJGrUqCEWLVokDh8+LKZNmyZcXFzE6NGjpbJWrlwpVCqVGDVqlLT9np6e4scff8x324UQ4vbt20KlUolNmzZpbUft2rXFkiVLxNGjR0WnTp2Ei4uLaNq0qYiIiBBHjx4V/fr1EyqVSpw9e1YIIcTz589Fq1atRN26dcX69evF/v37Rf/+/YWrq6s4evSotD6VSiV8fHzE8OHDxaFDh8Tq1auFu7u7GDRokBBCiJs3b4ru3buLevXqidOnT4ukpKR82+3atWtCpVKJQ4cOaU1XqVTCy8tL/Pjjj+Lo0aMiLCxMqFQq0bRpU/Hdd9+JQ4cOicjISKFSqcTChQul9i3IfjJjxgyhUqmk7enTp4/w8/MTCQkJr3x9Q0JChJeXlwgJCREHDhwQ69atE25ubqJp06aiVatWYs+ePWL79u2iRo0aonv37tJy27dvFyqVSnz//ffiwIEDYvXq1cLX11d8++23QqPRCCGE+PPPP4VKpRITJ04UR48eFfv27RPdunUTKpVKnDlzRuv11NUvb926JTw8PMS4ceNETEyM2L17t2jatKlo2LChUKvV+W5XRkaGaNasmQgICBBbtmwRe/bsEV9++aWoXr26Vh8bOXKkcHNzExEREeLw4cMiKipKeHp6ii5dukjbERISIkJCQqRl+vfvL2rUqCGWLVsm9u/fL3r37i3tk7lOnDgh3NzcRNeuXcW+ffvEli1bRGBgoPjss8+kfX3Tpk3CyclJBAYGiujoaHH06FHpGHnw4MFXvmbnzp2Tyt6/f79YuXKlqFWrllCpVGLWrFlCCCHS09NFixYtRJ06dcSaNWvEwYMHxZgxY4RKpRLz5s2TygoPDxcuLi7il19+EUeOHBHz588Xzs7OYv78+a9c/4uePn0qqlevLvVVIXL2Y5VKJYYOHSpNmz9/vqhdu7ZQq9XiwoULwtXVVQwePFgcOnRIHDx4UPzwww9CpVKJHTt2CCGEiI2NFS4uLiIyMlIcO3ZMbN26VdSrV0906NBBKjMoKEj4+PiIHj16iP3794tt27YJPz8/8dVXX+WpZ1JSkrR//PHHH+LmzZv5bk9uf6xXr5747bffxJYtW8TTp09f+3o+efJEOr6tXLlSXLlyRQiR03dcXV3F8OHDxdGjR8Xhw4fzHNOSkpKEv7+/aNKkidi+fbvYs2ePCAkJETVq1BBXr14VQggxe/Zs4eHhIZ48eSLV9erVq0KlUonffvtNCFGwfbIgfSfXkSNHhEqlEtevXy9QXxBCiEKHBZVKleefk5OTaNmypbRhQuS8EYWGhoqTJ09qlTFhwgRRvXp1rTI9PT21GmrLli1CpVKJv//+Wwjxv7Dw6NEj8dlnn4mWLVuKR48e6axr27ZtxaeffioFDiGESElJEX5+fmLAgAHStPwa8kVHjx4VKpVK7N69W5qmVqtF8+bNpQPI48ePRfXq1aU3xlwnT56UOpgQ2m+YKSkpws3NTUyZMkVrma5du2qFhcGDB4u6detqtU9ycrLw8fER4eHhQoj/7QQzZszQKqthw4aiZ8+er9y28PBwUaNGDa03xTNnzgiVSiWFhf3792vt6LnmzJkjVCqVuHz5slCr1aJOnTqiT58+WvMsWrRIBAcHi8zMzEKFhRfbJLc+P/zwgzTt0aNHQqVSiaVLlwohhFi3bp3Wm5QQOW/CHTp0EK1bt5amqVQq0a5dO606DB8+XNSoUUN6nF89X7Zq1SqhUqlESkqK1nSVSiW+/PJL6XF2draoUaOGaNiwocjKypKmt2jRQvTu3VsIUfD9JDMzU7Rs2VI0bdpUbNq0SetA8iohISHC3d1dK1Tn9q9bt25J08aPHy98fHyEEDntFhAQILp27apVVu5+8OeffwohhFi4cKHUR3IlJycLlUolFixYIIQoWL/csWOHUKlUWqHn7NmzYvr06Vp9/kUbNmzQOj4IIcSTJ09ErVq1pNfuypUrWnXJtXXrVqFSqcT+/fulNsoNC5cvXxYqlUqsXr1aml+tVotPP/1UKyx8/fXXokWLFlrHluvXrwsXFxdpX899jdavXy/Nk5GRIdzd3cX48ePz3S4hcsJKQECAyMzMlKbt3LlT6ziV2/9OnTqltezIkSOFu7u7SE5OFikpKcLV1VWEhYVpzTNhwoQ8r60uXbp00QqtAQEBIjg4WGsf6dChg9QXtmzZIrp166YV9NRqtfDx8ZGOjwsWLBBeXl5aH872798vIiMjpTe+oKAgERQUpNXGuUE7v2N/bnvnHjfzk9sf58yZozW9IK9n7rLHjh2T5sl973pxO14+pk2fPl24u7uL+Ph4aZ6MjAzRqFEj0b9/fyFETmB2cnISW7ZskeaJiIgQNWvWFBkZGQXeJwvSd3KlpqYKlUolVq1a9cr2elmhT0O4ublh48aN2LhxI+bOnQuVSoUqVaogIiICzZo1k+arUKECli9fDh8fH8THx+PIkSNYsWIFTp06JQ1N5/r4449haWmptSwApKena83XrVs3XLlyBSNHjoS1tfUr6/js2TP8/fffaN68ORQKhTTdysoKQUFBOHHiRIG399ixY1Aqlfjkk0+kaXK5HJ9++qn0+MyZM8jMzESLFi20lq1Zsybef//9fNd35swZZGVlISgoSGt68+bN86zfz88PpqamyM7ORnZ2NiwtLVGzZs08Q0xeXl5ajx0cHPIMU70oLi4ONWrU0LpAz9PTE++99570+MSJEzAyMtJ6bQGgVatW0vM3btxAUlISGjdurDVP165dsXnzZiiVylfWIT8vboetra1Ur1y5r/2TJ08AADExMShfvjzc3NykNlKr1QgKCsK5c+e0Tu28fD7RwcEhTz97ndu3b8PKygpWVlY6665QKGBtbQ03NzcYGf3v8qBy5cpJdS/ofqJUKjF58mTEx8dj1KhRCA4OzvOa5MfR0RFly5aVHtvZ2cHa2hqVK1fOtz7Xr19HQkICGjZsKLVldnY2fH19YWlpKQ3bduvWDeHh4Xj69CnOnTuHXbt2ScOaL+/fuvqlp6cnTExM0LZtW4SFheHQoUNwdnbGoEGDtI4JLzp27BgqV66M6tWrS9MsLS219qXcfe6zzz7TWvazzz6DQqHA8ePH85Sbe6X7i6cy5HI5mjZtKj1OT0/H2bNn0aBBAwghpPapXLkyHB0dpfbJb9uNjY1hY2Pz2n3S399fa59p0qSJ1nHsxIkTeP/99/O0a6tWrZCRkYGzZ8/izJkzyM7OznNOevTo0Vi0aNEr1/+ywMBAxMXFITMzEzdu3EBCQgJ69eqFO3fu4M6dO0hLS8Pp06cRGBgIAPjiiy+wcOFCZGVl4eLFi9i9ezdmzZoFtVqNrKwsAICvry/S09PRokULTJs2DbGxsahfvz769eundRrb3d1da7sdHBwA5H1fKCwXFxfp/4V9PV9WtWpVrVORL4uJiYGLiwsqVKgglS2XyxEQECAdvytXrgxvb2/s2rVLWm7nzp1o1qwZjI2NC7xPFqTv5CpTpgysrKwKddddoS9wtLCwgLu7u/TY09MTrVq1QpcuXbB582atN57t27dj+vTpuHfvHsqVKwcXFxeYmprmKdPMzEzrsVyek2FePieenp6OSpUqYdq0aVi3bp0038uePHkCIQTs7OzyPGdnZycdGAsiOTkZ5cqVy7Ou3DcxANKbUWHWl7vMy6GnfPnyWo8fP36MXbt2aXWkXC9fhf9y28rlcp3nJ1NSUlCpUqU801+sQ0pKCqytrfN0uNx5njx5gsePHwPQbpM3kd+bxMt95EWPHz/Gw4cP4ebmlu/zDx8+lN4w8+trutooP2lpaa+sT351Nzc311leQfcTFxcXODk54dy5c3lC5qsUtj65r+W4ceMwbty4PM8/ePAAQM51FmPHjsXevXshk8nw4YcfombNmgDy3ouuq19WqlQJK1euRFRUFDZu3Ijly5fDysoK7du3x8CBA/O9Wjs5OTnfvpbfPvny/mRkZARra+si75OpqanQaDRYuHAhFi5cmKcMExOTAm97fnL3t/zq/OI8L28X8L/jT2pqqrSON71TJzAwEBMnTsSpU6dw/fp1fPTRRwgKCoK5uTlOnjwJc3NzyGQy1K9fHwDw/PlzTJgwAdu2bUN2djYqVaoELy8vGBkZSXXy8vJCVFQUoqOjsXTpUkRFRcHOzg69evXSuo21oO8LhfVi/y/s6/kyCwsLnc8/fvwYN2/efOWxKT09HWZmZvj8888xYcIEJCcnIz4+Hjdv3sSkSZOkMoDX75MF6TsvMjMzQ1pams76a5VV4Dlfwc7ODmPGjMF3332HsLAwTJs2DUBOSh82bBhCQ0PRtWtXabTgl19+QVxcXJHWtWzZMly4cAHdu3fH8uXL0alTp3znK1OmDGQymXTh2osePnyIcuXKFXidFSpUQHJyMjQajVZgSEpKkv6f+0aUmJiIqlWr5lnfi5/icuW+gElJSVrL5HaMF7elbt266Ny5c54yXvy0WhTW1tb5ttGLdShbtiySk5OhVqu1AkNuB7W2tpY+Yb/8fQPJyck4f/48vLy8IJPJ8lxsqesTVmGUKVMGVapUwdSpU/N9Pr9A9CZe9WZTFIXZT9atW4dz587B2dkZYWFhqFOnTr6jG28it7yhQ4fCz88vz/O5fX3IkCG4fv06oqOj4eXlBWNjY6Snp2P9+vWFXqeHhwdmz56NzMxMxMXFYd26dZg/fz6cnZ3zjLQBOfvkixe65cpvn3z48CHef/99aXpWVhaSk5PzPYDmTktMTNQaXXtxf7CwsIBMJkOnTp3yjFoAukNtQZQrVy7PPimE0BodK1u2LG7evJln2YcPH0rbkZ2dDSBnn3zx+HL37l3cunULPj4+BRrxq1y5MqpWrYqYmBjcuHEDfn5+UCqV8Pb2xvHjx6FQKKRPuAAQFhaG3bt3IyIiAnXr1pXemOvUqaNVrr+/P/z9/ZGeno5jx45h+fLlmDhxIjw9PeHh4VGQptKL4n49y5QpAz8/PwwdOjTf53NHJZo3b46JEydi7969uH79Ot5//334+PgAKPg+WZC+86LU1FSdI/Qv08vdEM2aNYO/vz927NghDf+dPn0aGo0G/fv3lw6AarVaGnopSjosX748AgIC0Lx5c8ycOfOVQyjm5uaoXr06fvvtN603qCdPnmD//v3Si1AQfn5+yM7Oxr59+6RpQgjs3btXeuzp6QljY2Ps2LFDa9nY2FjcvXsX3t7eecr18vKCqakpfv/9d63pf/75Z571X716FS4uLnB3d4e7uzuqV6+O6Oho7Nmzp8DbkZ/atWvj9OnTWlchX716VetOi9ztf7meuXdN+Pj4oGrVqrC2ts5T923btqFHjx7IysqChYUFkpOTta4sL2pofJmfnx/u3bsHW1tbqY3c3d1x5MgRLFq0KN9huFd51WjVi9577z08e/ZM550uBVXQ/eTOnTuYPHky2rZti/nz5+PJkycICwt74/W/rGrVqrC1tUV8fLxWW1aoUAHTpk2TruKOi4tDkyZNUKtWLemAd/DgQa06F0R0dDSCgoKQmZkJY2Nj1KlTBxMmTACQ88aWHz8/P8THx+PChQvStOfPn+PQoUNa8wA5w7kv2rlzJ9Rqdb7HgNq1awOAzn3S0tISrq6uuH79ulb7VKtWDZGRkfme3iiMOnXq4ODBg1pD7YcOHZKG8IGcYfw7d+5Idx/k2r59O5RKJTw8PODh4QGlUplnn1yyZAkGDx5cqH0iMDAQx48fR1xcnHSLea1atXD8+HEcOnRIa5Qrd55PPvlECgrnzp3Do0ePpH4xefJktGnTBkIImJmZISgoCMOGDQPw6tf8dQqy3+anoK9nYdrrRX5+frhx4wY++ugjrfK3bduGjRs3SuXmniL/z3/+g927d6NVq1bSqFpB98mC9J1cKSkpSE9P1wrFr/PGIwu5Ro4ciVatWmHixInYsmWLlA7Hjx+PNm3aICUlBatWrcLFixcB5HyqfNU5yYKs69ChQxg7duwrb0X6/vvv0bVrV/To0QPt27dHVlYWoqKikJmZib59+xZ4Xb6+vqhXrx5GjRolfeLYuHEjLl26JL2Y5cqVQ48ePTBnzhwolUoEBQUhPj4eM2fOxMcff4zg4OA85VpYWKBPnz6IiIiAmZkZateujQMHDuTZufv06YNvvvkGPXv2RLt27WBiYoJ169Zh7969mDVrViFaLa9vv/0WGzduRNeuXdG/f3+o1WrMmDFD6xNHQEAAatWqhdGjR+P+/ftwdnbGiRMnsHDhQgQHB+Pjjz8GAPTv3x/jx4+Hra0tGjZsiBs3bmDWrFno0KEDypYti6CgIKxYsQKjRo1C27ZtcfnyZSxdurTIO+GLWrdujZUrV6Jz587o1asXKlasiKNHj2LhwoUICQkp1DUTVlZWSExMxIEDB+Di4pLvfdz16tUDkHNgfN03cr5OQfYTCwsLjBo1CmZmZhg6dCjKli2LgQMHYtKkSWjatOkb1+FFCoUCgwYNwpgxY6BQKBAUFITU1FTMnTsX9+/fl4ZTPTw88Ouvv8LNzQ0ODg44deoUoqKiIJPJCnVOuXbt2pg6dSr69u2LkJAQKBQKrF27FsbGxq881dKiRQtERUWhb9+++O6772BlZYWlS5ciKSlJOvjl7nezZs1Ceno6fH19ceHCBcyePRu1atWCv79/nnI//PBDfP3115gxYways7Ph4uKCbdu24dKlS1rzDR48GD169MD333+PVq1aQa1WY8mSJTh79iz69OlT4G3PT9++fbF371507doV3bp1w6NHjxAREaHVh1u3bo3Vq1ejb9++GDBgACpVqoR9+/Zh06ZN6Nevn/RJtGPHjoiOjoaxsTH8/Pxw9uxZrFmzBkOHDoVcLkdaWhquXr2KDz74QOfpigYNGmDJkiUA/hfCateuLY0iv/g6eXh44LfffsOaNWvg6OiIixcvYt68eVr9onbt2li6dCmGDx+OVq1aISsrC4sWLUK5cuWkwFZYudu8Z88eBAQEwNHRscDLFuT1LFOmDABg//79KFu2LJydnQtUdqdOnbBt2zZ06tQJXbp0gbW1NXbt2oX169dLt3vmatWqFQYMGAC1Wo3PP/9cml7QfbIgfSdX7ge13NNHBaG3sFC1alWEhoZiyZIlWLNmDUJCQjBmzBgsXboUv//+O+zs7FCrVi3Mnj0bffv2RVxcXJG/vMne3h6DBw/G+PHjsXXrVnzxxRd55qlTpw6WLl2KWbNmYfDgwTA2NkbNmjUxefJkVKtWrVDrmzFjBsLDwzFt2jRkZ2ejUaNGaNeuHbZu3SrN079/f9jZ2WHlypVYt24dypUrh2bNmmHgwIGvPEfcs2dPmJubY9myZVi2bBm8vLwwbNgw/PTTT9I8zs7OWLVqFWbMmIGhQ4dCCAGVSoU5c+agUaNGhdqOl1lbW2PNmjUICwvD8OHDYWFhgW7dumldHyGTybBgwQLMmjUL0dHRePToESpVqoTBgwdrnRrp0KEDzM3NsXjxYqxbtw4ODg7o3r07unfvDiDnDXbYsGFYsWIFdu/eDTc3N8yePRvffPPNG20DkDOStGrVKkybNg1TpkzBkydP8P777+P7779Hly5dClVW69atceDAAelAnN9XP1euXBlubm44cODAG79R16pV67X7SXx8PGJiYhARESENOYaGhuLXX3/FmDFj4O3tXahTa6/z5ZdfwsLCAosWLcK6detgbm4Ob29vTJ06VTqlFh4ejgkTJkijAFWqVMG4ceOwffv2134l7oucnZ0xf/58zJkzB4MHD4ZarUb16tWxZMmSPKf0chkZGWHx4sUICwvDTz/9BCMjI7Rq1QrlypXDjRs3pPnCwsLw4YcfYtOmTVi4cCHs7e3RsWNH9OnT55WfRMeOHSvtxykpKfD390evXr0QEREhzVO/fn0sXrwYs2fPxoABA6BUKuHm5oalS5e+8RfyVKlSBStXrkR4eDgGDRoEW1tbDBs2DOHh4dI8ZmZmWLFiBaZNm4aZM2ciLS0NVatWRVhYGNq2bSvN98MPP8DW1hZr167FokWLUKlSJfz444/SPvd///d/6NixI37++We0bt36lXXy8fFBmTJlYGdnJ10r4ebmBktLS1SoUEHrNOvw4cORlZWFiIgIZGZmolKlSujduzeuXr2Kffv2Qa1Wo0GDBpg6dSqWLFkiXdTo4+OD5cuXF7kf16pVC3Xr1sW0adMQExODqKioAi9bkNezWrVqaNGiBVatWoVDhw7lGUV+lQoVKmDt2rWYNm0afvrpJ2RkZKBKlSp5XisgJ5SVKVMGlStXxkcffaT1XEH2yYL0nVwHDx6Eh4eH1im615GJwl7d9S9z584dnDlzBo0aNdK6WGnAgAG4ffs2tmzZYsDakaHs3r0bI0eOxMGDB197kRPp15UrV3D9+nU0adJE6wLItm3bwsHBAbNnzzZg7YhKtmfPnsHf3x+TJ0/WusvvdfQ2slBayeVyDB8+HI0aNULbtm2hUChw6NAh/PHHH/j5558NXT0ykCZNmmDp0qVYs2YNunXrZujq/Ks8e/YM3333Hdq3b4/GjRtDrVZj165dOHfuHIYMGWLo6hGVaGvXrkW1atUKPTLNkYUCOHbsGObMmYMLFy4gOzsbjo6O6Ny5c57vVaB/l1u3biEkJARbt27lj0m9Zb///jsWL16Ma9euQQgBV1dX9O7du1DnYIn+bR49eoQvvvgCK1aswIcfflioZRkWiIiISCe9/ZAUERERlU4MC0RERKQTwwIRERHpxLBAREREOvHWyZcIIaBWa6BWZ0OhMMr3h2wKXs6blVFasW2KF9u3eLF9i1dJaF+5XMbX9iUMCy/RaATu33+EhIRbcHD4AMbGeX/9ryAyM5+/cRmlFdumeLF9ixfbt3iVhPa1sbGAQsGw8CKehiAiIiKdGBaIiIhIJ4YFIiIi0olhgYiIiHRiWCAiIiKdeDcEEZUIGk3OLcslXXZ2lvRXJuPnLX17G+2rUBhBLudrVxgMC0RkUEIIpKY+Qnp6mqGrUiBCCMjlCqSkJPFe/GLwttrXzMwSVlY2fA0LiGGBiAwqNyhYWlrD2NikxB+8NRoNsrOzYGSk5KfTYlDc7SuEQGZmBtLSkgEAZcva6n0dpRHDQjGQy2VQKo1gZmYGpdIIRkZF6/AajYBGw18Qp9JLo1FLQcHS0srQ1SkQjUYDAFAqjRkWisHbaF9jYxMAQFpaMsqUsebrWAAMC3oml8tgbW0BuVwGe3vrNypLoxFITn7KwEClllqtBvC/gzfR25Lb59TqbMjlxgauTcnHsKBncrkMcrkMB26nIjEtHUqlMWTywg+rljVWIKBSGcjlMoYFKvVK+qkHKn3Y5wqHYaGYpGSokZieBWO1nENcREWQG7wNgacAibQxLBBRifPi6TxDKOopwOzsbGzevAG7d+/CrVs3YWJijGrVnBAa2hne3jWLqbZv5vr1a0hIuIe6desbuipUgjEsEFGJkzuqcDD+CVIy1W913UU9BZiRkYFBg/ri/v0EdOvWC9WreyAjIwM7d27HwIF9MHr0eDRp0qwYa140w4YNQrNmnzEskE4MC0RUYqVkqvHo+dsNC0W1ePF8XLt2BcuXr0OFCg7S9O+++x5Pn6Zh5swpqF8/AObm5gasZV5C8HQLvR7DAhHRG8rOzsaOHdvx6aettIJCrh49+iA4uC1MTHKuwE9NTcHChfNx5MhBPH78GE5OTujevY90qmLx4gU4fToOtra2iIk5iubNP4OTkwuWLVuMOnXq47fffoW3d038/PM0/PPPDcyePQNnz56Gubk5vL190a/fQNja2gHICQMbNqzFli0bcP/+fbz33vv49tsuaNy4Gdq2bYmEhHtYunQhTp+Ow+zZUXnqnpqainnzZiEm5giSkx+hTBkr+Ps3wHffDYGpqSlOnYrFoEF9ER4+DXPnzkJ8/G1UrPgeevfuD3//QADA7du3MGPGFPzf//0FjUbA3d0DffsOhKPjx+jSJQQeHp4YOPAHAMChQwcwatQPGD/+ZzRs2BgAEBk5A1evXsHMmXORlpaGOXNm4tChP5GVlQUnJxf06TMAzs6ur2y7QYOG6vcF/xfilXdERG/o7t14pKamwN3dM9/n7ezKw8XFDQqFAmq1GoMG9cNff53Gjz+Ox+LFK1C16scYPLgfLlz4P2mZM2dOwcbGDkuXrkLbtt8AAO7ciUdi4kMsWbIK3bv3QWLiQ/Tt2w2VKn2ARYtWYPLkCDx9moZevbogPT0dALB69XJERc1Bhw4dsWLFOnzxRWtMnDgWp07FYuHC5bC3r4BvvgnBpElT8q37pEk/4fLlSwgLm4K1a7dgwIDB+P33ndi+fbM0j1qtxty5szBw4A9YvnwdqlZ1xMSJY/Hs2TMAwNixI1G+fHksWrQCUVHRkMvlGDlyCACgXj1/nDx5XCorNvYEZDIZTp2Kk6bFxByGv38AhBD44YcBuHv3DiZPjkBU1DK4ubmjd++uuHz5os62ozfDkQUiojeUmpoKAChTpsxr5z1x4hguXbqA5cvXomrVjwEAQ4aMwIUL/4fVq1dgwoRwad6uXXvC0tISAPD332cBAJ06dcP771cCACxcOA/ly1fAwIFDpGXGjw/HZ581wp9/7kXz5i2wfv0afPllO7Ro8QUAoG3bb5CRkYHs7GxYW+d8IZGZmRmsrMrmW19f31qoUcMHjo45da1Y8T1s3LgO165d1Zqve/c+8PHxBQB8+2037N+/D9evX0X16h64ezcevr61ULHiezAyMsKIEWNw8+Y/0Gg0qF+/AZYuXYj79xNQoYIDYmOPo27d+jh9Oics3LkTj1u3bqJ+/QaIizuJc+f+xs6de6X69uzZF3//fRYbNqzFqFE/5dt29OYYFoiI3lC5cjlfwJaamvLaea9fvwpLS0spKAA59/x7enrjxIkYaZq1tU2+b3aVK1eW/n/58kXcuHENjRv7a82TmZmJf/65gZSUFCQlJcLNrbrW8x06fFuwDQMQHPwlDh8+iF27fkV8/C3cuHEd9+7dxYcfVtGar0qV/z3OrXdWVs6PQnXv3gezZk3Dli0b4eXljVq16uKTT5pCLpfDyckZ5cvb4+TJ46hZsxbu3r2D4cN/RN++3ZGUlIijRw+jWjUVHBwqYt++PRBCoE2bFnm2NyMj47VtR0XHsEBE9Ibee+992NjY4u+/z6JRoyZ5nv/nnxuYOXMq+vcf/MoLCoXQwMjof4fk3OsbXmZiYir9X6MR8Pauie+/H55nPkvLMlrlFYVGo8HQoQNx/fo1NG7cDI0aNYFK5YxffgnLM69SmfdbEHO3tU2br9Cw4SeIiTmCuLgTWLRoPpYtW4SlS1fDxsb2v6cijgEAXFzc4OzsgvLl7XHqVCxiYg6jfv0GUn0sLCywePHKfNavlP7/qrajouM1C0REb0gul+Ozz1ph164duH8/Ic/zq1cvx4UL51Gx4ntwdKyGtLQ0XL/+v2F8IQT++usMqlT5qFDrrVrVETdv/gN7+wqoVKkyKlWqDCsrK8yaNU0awbCzK48LF85rLTd69DBERk4HoPubDK9cuYxjx45iwoTJ6N27P5o0aY5KlSrjzp3bBb6LIjn5EaZPn4ysrCx8+mlL/PjjBCxbtgZJSUk4ffoUgJzrFuLiTiIu7qR0KsPbuyYOHz6I06fj4O/f4L/b+zGePn2KrKwsaXsrVaqMVauW4fDhA4VqOyochgUiIj349tuuqFz5A/Tp0w2//74Td+7E48KF/8OkSePw++87MWzYKJiZmcHPrzaqVVNh3LjROH06Dv/8cwPTp/+Ca9eu4ssv2xdqncHBbZGWlobx40fjypXLuHLlMsaMGYELF87jo48cAQAhId9i/fo12L17F+7ciceGDWtx6NB+6dO6mZkZ4uNv49GjpDzl29raQqFQYN++Pbh79w4uXjyPH38cjqSkJGRlZRaojmXKWCEm5ggmTw7DlSuXcOdOPLZt2wylUglnZxcAgI+PHzIyMnDgwD4pLPj4+OLPP/fCxsYWKpUzAKBWrTqoVk2FsWNH4NSpWMTH30Zk5HTs2vUrqlSpWqi2o8LhaQgiKrHKGivemXWamppi9uworFmzAitXLsP9+/dgYmIKlcoZkZEL4OnpBQBQKBSYPn0O5syJwMiRPyArKxPOzq6YOXMeqld3L9Q633vvfcyevQDz589Gnz5doVAo4O7uiVmz5sPaOuc6ijZtvkZGRgYWLZqPpKREVK78AcaP/xleXj4Aci54nDMnAtevX8OyZWu0yrezK49Ro8ZhyZIF2LJlA2xsbFG3bn18/XV7HD58sEB1NDIywpQpMzFnTgS++64Pnj9/jmrVVPjllwjpQk1jY2PUrFkLJ07EwM3NHYBAzZp+/70AMkAqS6FQYMaMuZg7dybGjBmO9PR0VKlSFWFhU6SQQcVDJviNHFrUag0SEpKQkHALDg4fwNjY9PULvcDISA5rawtsv5qMe6lPYWxsUqTfhrAxVaBl1XJITn6K7GxNoZcvyTIznxe5fen13qX2zcrKRFLSPdjaVtQ6512Sv+5Zo9EgKyuTP1FdTN5W+76q7wGAjY0FFAq+ti/iyAIRlTi5b9b8ISmikoFhgYhKJL5hE5UcHGchIiIinRgWiIiISCeGBSIiItKJYYGIDI43ZdHbxj5XOAwLRGQwCkXOdxpkZma8Zk4i/crtcwoFr/MvCLYSERmMXK6AmZkl0tKSAQDGxiY6v364JNBoNMjOzvmBJH7Pgv4Vd/sKIZCZmYG0tGSYmVnyNSwghgUiMigrKxsAkAJDSSeEgFqthkKhKPHB5l30ttrXzMxS6nv0eiU6LGRnZ2POnDnYunUrHj9+DFdXV/zwww+oUaMGAODChQsICwvDuXPnYGNjg06dOqFjx46GrTQRFYpMJkPZsrYoU8YaanW2oavzWllZGUhMvAcbG3solfx1Q317G+2rUBhxRKGQSnRYmDdvHjZs2IDw8HBUrlwZCxcuRLdu3bBr1y4olUp07twZDRs2xLhx43DmzBmMGzcOFhYWaNOmjaGrTkSFJJfLIZfn/ZnjkkaInK9fNzJS5vuzzPRm2L4lU4kOC3v37kWLFi1Qv359AMDw4cOxYcMGnDlzBjdu3IBSqcT48eNhZGQER0dH3Lx5E1FRUQwLREREelSix2FsbW3x559/Ij4+Hmq1GuvWrYOxsTGcnZ0RGxsLPz8/GBn9L+/Url0b//zzDxITEw1YayIiotKlRI8sjBo1Ct999x0aNWoEhUIBuVyOyMhIfPDBB0hISIBKpdKa397eHgBw79492NnZFWmdQgjpd9oL+nvt2ssbAbCQ7uEVQkCjKfyvRgqNXKpDVlbJP49bGG/SvvR6bN/ixfYtXiWhfYUwN9i6S6oSHRauXr2KMmXKYM6cOahQoQI2bNiAIUOGYOXKlXj+/DmMjbXPZ5mY5FwMk5FR9Hu21epsJCUlAID0tzDMzMxgb28t3fpT1A6fpcgJGImJ95Cenl6kMkq6orQvFRzbt3ixfYuXIdvXzs4KRkYKg62/JCqxYeHevXv4/vvvER0djZo1awIA3N3dcfXqVURGRsLU1BSZmdpvxLkhwdy86KlQoTCCra0DkpISYGvrUOgLbJTKnCY1MlICyIJSaVyk239yy7Gzq1gqRxaK2r70emzf4sX2LV4loX35RU15ldgWOXv2LLKysuDu7q413dPTEwcPHsR7772HBw8eaD2X+7hChQpFXq9MJpM6qFJpDGNj00Itb2Qkl8rJ/VuUW3RkcplUB5msxL5Mb6Qo7UsFx/YtXmzf4mXI9uX3Z+RVYi9wdHBwAABcunRJa/rly5dRpUoV+Pr6Ii4uDmq1Wnru2LFj+Oijj2Bra/tW60pERFSaldiw4OHhAR8fHwwbNgzHjh3DP//8g4iICMTExKBHjx5o06YN0tLSMGrUKFy9ehWbN29GdHQ0evbsaeiqExERlSoldnxbLpdj3rx5iIiIwIgRI5CSkgKVSoXo6Gh4enoCABYtWoSwsDAEBwejfPnyGDp0KIKDgw1ccyIiotKlxIYFAChbtizGjh2LsWPH5vu8h4cH1q1b95ZrRURE9O9SYk9DEBERUcnAsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTiU+LGzduhWffvop3N3d8dlnn+G3336TnouPj0fPnj3h7e2N+vXrIyIiAmq12oC1JSIiKn1KdFjYtm0bRo0ahQ4dOmDnzp1o0aIFBg8ejNOnTyMrKwtdu3YFAKxduxY//fQT1qxZgzlz5hi41kRERKWLkaEr8CpCCMycORMdO3ZEhw4dAAC9e/dGbGwsTpw4gTt37uDu3btYv349ypYtC5VKhaSkJPzyyy/o1asXjI2NDbwFREREpUOJHVm4ceMG7ty5g5YtW2pNX7x4MXr27InY2Fi4ubmhbNmy0nO1a9dGWloaLly48LarS0REVGqV6LAAAM+ePUPXrl1Rp04dfPnll9i3bx8AICEhAQ4ODlrL2NvbAwDu3bv3ditLRERUipXY0xBpaWkAgGHDhqFfv34YMmQIdu/ejT59+mDp0qV4/vw5rKystJYxMTEBAGRkZBR5vUIIZGVlAoD0t3DLGwGwgBBCKk+j0RS+HI1cqkNWVnahly/J3qR96fXYvsWL7Vu8SkL7CmFusHWXVCU2LCiVSgBA165dERwcDABwcXHB+fPnsXTpUpiamiIzU7sz5YYEc/Oiv9BqdTaSkhIAQPpbGGZmZrC3t0Z2dhaAonf4LEVOwEhMvIf09PQilVHSFaV9qeDYvsWL7Vu8DNm+dnZWMDJSGGz9JVGJDQsVKlQAAKhUKq3pH3/8Mfbv3w8/Pz9cvnxZ67kHDx5oLVsUCoURbG0dkJSUAFtbByiVhbtQUqnMaVIjIyWALCiVxpDJZIWuR245dnYVS+XIQlHbl16P7Vu82L7FqyS0r0JRYt8aDabEtoibmxssLCxw9uxZ1KxZU5p++fJlfPDBB/D19cXWrVuRlpYGS0tLAMCxY8dgYWEBZ2fnIq9XJpNJHVSpNIaxsWmhljcykkvl5P6Vywt/aYhMLpPqIJOV2JfpjRSlfang2L7Fi+1bvAzZvkX5gFfaldgLHE1NTdGtWzfMmTMHO3bswK1btzBv3jwcOXIEnTt3xieffILy5ctj4MCBuHjxIvbu3Yvp06ejS5cuvG2SiIhIj0r0R9Y+ffrAzMwMM2bMwP379+Ho6IjIyEjUqlULALBo0SKMGzcOX331FcqWLYv27dujT58+Bq41ERFR6VKiwwIAdO7cGZ07d873uQ8//BBLlix5yzUiIiL6dymxpyGIiIioZHjrYSEhgbcbERERvUv0HhZcXFzw119/5ftcbGwsmjdvru9VEhERUTHSyzULS5YswbNnzwDkfGPhhg0bcPDgwTzznT59mncqEBERvWP0EhYyMjIwe/ZsADn3p27YsCHPPHK5HGXKlEHv3r31sUoiIiJ6S/QSFnr37i2FAGdnZ6xfvx4eHh76KJqIiIgMTO+3Tl68eFHfRRIREZEBFcv3LBw5cgR//vkn0tPT8/ziokwmw6RJk4pjtURERFQM9B4WlixZgl9++QUmJiawsbHJ8x3b/M5tIiKid4vew8LKlSvRsmVLhIWF8c4HIiKiUkDv37OQmJiItm3bMigQERGVEnoPC66urrhy5Yq+iyUiIiID0ftpiJEjR2LgwIEwNzeHp6cnzMzM8szz3nvv6Xu1REREVEz0HhbatWsHjUaDkSNHvvJixgsXLuh7tURERFRM9B4WJkyYwDseiIiIShG9h4XWrVvru0giIiIyIL2HhZMnT752Hl9fX32vloiIiIqJ3sNCaGgoZDIZhBDStJdPS/CaBSIioneH3sPC8uXL80x79uwZYmNjsW3bNkRGRup7lURERFSM9B4W/Pz88p0eGBgIc3NzzJs3DwsWLND3aomIiKiY6P1LmXSpWbMmTpw48TZXSURERG/orYaFffv2wcLC4m2ukoiIiN6Q3k9DdOzYMc80jUaDhIQE3LlzB927d9f3KomIiKgY6T0svHgXRC65XA6VSoWePXuiTZs2+l4lERERFSO9h4UVK1bou0giIiIyIL2HhVwHDx7EiRMnkJqaChsbG/j4+MDf37+4VkdERETFRO9hITMzE3369MHhw4ehUChgbW2N5ORkLFiwALVr18aCBQtgbGys79USERFRMdH73RCRkZGIi4vDL7/8gr/++guHDx/G2bNn8fPPP+PMmTOYN2+evldJRERExUjvYWHHjh3o168fWrVqBYVCAQAwMjLCF198gX79+uHXX3/V9yqJiIioGOk9LDx69Aiurq75Pufq6or79+/re5VERERUjPQeFj744APExcXl+9zJkydRsWJFfa+SiIiIipHeL3D85ptvEB4eDlNTU3z22Wews7NDYmIiduzYgYULF6Jfv376XiUREREVI72HhXbt2uH8+fOYOnUqpk2bJk0XQiA4OBg9evTQ9yqJiIioGBXLrZNhYWHo0qULTpw4gZSUFMhkMnzyySdwdHTU9+qIiIiomOntmoVLly6hTZs2WLp0KQDA0dER7dq1Q/v27TFz5kwMHjwYN27c0NfqiIiI6C3RS1iIj49Hx44dkZiYiI8++kjrOaVSiaFDh+Lx48do374974YgIiJ6x+glLERFRaFcuXLYsmULmjVrpvWcmZkZOnXqhI0bN8LExAQLFiwo0jpu3LgBLy8vbN68WZp24cIFhISEoEaNGmjYsCGWL1/+RttBREREeeklLMTExKBbt26wsbF55Tzly5dHly5dcOTIkUKXn5WVhSFDhuDZs2fStOTkZHTu3BkffPABNm3ahL59+2Lq1KnYtGlTkbaBiIiI8qeXCxwfPHiAKlWqvHY+lUqFhISEQpcfGRkJS0tLrWnr16+HUqnE+PHjYWRkBEdHR9y8eRNRUVH8GWwiIiI90svIgo2NDR48ePDa+ZKTk1G2bNlClX3y5EmsW7cO4eHhWtNjY2Ph5+cHI6P/5Z3atWvjn3/+QWJiYqHWQURERK+ml7Dg6+urdS3Bq2zduvWVXwWdn9TUVAwdOhSjR4/O882PCQkJcHBw0Jpmb28PALh3716B10FERES66eU0RGhoKNq1a4fw8HAMGjQIJiYmWs9nZmYiIiICBw8eRFRUVIHL/emnn+Dl5YWWLVvmee758+d5fuo6d70ZGRlF2IocQghkZWUCgPS3cMsbAbCAEEIqT6PRFL4cjVyqQ1ZWdqGXL8nepH3p9di+xYvtW7xKQvsKYW6wdZdUegkL7u7uGDFiBCZNmoRt27ahTp06qFSpEtRqNe7evYvjx48jOTkZ3333Hfz9/QtU5tatWxEbG/vKX6k0NTVFZqZ2Z8oNCebmRX+h1epsJCXlXFeR+7cwzMzMYG9vjezsLABF7/BZipyAkZh4D+np6UUqo6QrSvtSwbF9ixfbt3gZsn3t7KxgZKQw2PpLIr19g2OHDh3g7OyMxYsX4z//+Y/0xm1hYYH69eujS5cu8PT0LHB5mzZtQlJSEgIDA7Wmjx07Frt27YKDg0Oe6yRyH1eoUKHI26FQGMHW1gFJSQmwtXWAUmn8+oVeoFTmNKmRkRJAFpRKY8hkskLXI7ccO7uKpXJkoajtS6/H9i1ebN/iVRLaV6HQ+5cbv/P02iI+Pj7w8fEBkPNT1UZGRrCysipSWVOnTsXz58+1pjVp0gQDBgxAq1atsG3bNqxduxZqtRoKRU4CPHbsGD766CPY2toWeRtkMpnUQZVKYxgbmxZqeSMjuVRO7l+5vPCXhsjkMqkOMlnp7LhFaV8qOLZv8WL7Fi9Dtm9RPuCVdnr/iepcNjY2RQ4KQM7owIcffqj1DwBsbW1RoUIFtGnTBmlpaRg1ahSuXr2KzZs3Izo6Gj179tTXJhARERGKMSwUN1tbWyxatAg3btxAcHAwZs+ejaFDhyI4ONjQVSMiIipV3qnx7UuXLmk99vDwwLp16wxUGyIion+Hd3ZkgYiIiN4OhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp1KdFh4/PgxxowZg4CAAHh7e6Ndu3aIjY2Vno+JiUHr1q3h6emJZs2aYefOnQasLRERUelUosPC4MGDcfr0aUyfPh2bNm2Ci4sLunbtiuvXr+PatWvo2bMn/P39sXnzZnz55ZcYOnQoYmJiDF1tIiKiUsXI0BV4lZs3b+LIkSNYvXo1fHx8AAA//vgjDh06hF9//RVJSUlwcnLCoEGDAACOjo44f/48Fi1ahDp16hiy6kRERKVKiR1ZsLa2RlRUFNzd3aVpMpkMMpkMqampiI2NzRMKateujbi4OAgh3nZ1iYiISq0SO7JgZWWFBg0aaE3bvXs3bt68iZEjR2LLli1wcHDQet7e3h7p6elITk6GjY1NkdYrhEBWViYASH8Lt7wRAAspsAghoNFoCl+ORi7VISsru9DLl2Rv0r70emzf4sX2LV4loX2FMDfYukuqEhsWXnbq1CmMGDECTZo0QWBgIJ4/fw5jY2OteXIfZ2YWvZOp1dlISkoAAOlvYZiZmcHe3hrZ2VkAit7hsxQ5ASMx8R7S09OLVEZJV5T2pYJj+xYvtm/xMmT72tlZwchIYbD1l0TvRFjYu3cvhgwZAm9vb0ydOhUAYGJikicU5D42MzMr8roUCiPY2jogKSkBtrYOUCqNX7/QC5TKnCY1MlICyIJSaQyZTFboeuSWY2dXsVSOLBS1fen12L7Fi+1bvEpC+yoU78Rb41tV4ltk5cqVCAsLQ7NmzTB58mRp9KBixYp48OCB1rwPHjyAubk5ypQpU+T1yWQyqYMqlcYwNjYt1PJGRnKpnNy/cnnhLw2RyWVSHWSyEv8yFUlR2pcKju1bvNi+xcuQ7VuUD3ilXYm9wBEAVq9ejQkTJqBDhw6YPn261mmHmjVr4sSJE1rzHzt2DN7e3kV6cyYiIqL8ldiPrDdu3MCkSZPQuHFj9OzZE4mJidJzpqamCA0NRXBwMKZOnYrg4GAcOHAAv//+OxYtWmTAWhMREZU+JTYs7N69G1lZWdizZw/27Nmj9VxwcDDCw8Mxd+5cTJkyBcuWLUOlSpUwZcoUfscCERGRnpXYsNCrVy/06tVL5zwBAQEICAh4SzUiIiL6d+LJfSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0MjJ0BUg3heLN85xGI6DRCD3UhoiI/o0YFkooM4UMQghYWZm9cVkajUBy8lMGBiIiKhKGhRLKWCGHTCbDoTtpeJyRXeRyyhorEFCpDORyGcMCEREVCcNCCZeSqcaj52pDV4OIiP7FeIEjERER6cSwQERERDoxLBAREZFODAtERESkE8MCERER6cSwQERERDq982FBo9Fg1qxZ8Pf3R40aNdC9e3fcvn3b0NUiIiIqNd75sDB37lysXr0aEyZMwNq1a6HRaNCtWzdkZmYaumpERESlwjv9pUyZmZlYsmQJhgwZgsDAQADAjBkz4O/vjz/++AMtWrQwbAVLkDf9jQn+vgQRFTe5XAal0ghmZmZQKo1gZFS04xaPV/r3ToeFixcv4unTp6hTp440zcrKCq6urjh58iTDAvT3GxP8fQkiKk5yuQzW1haQy2Wwt7d+o7J4vNK/dzosJCQkAAAqVqyoNd3e3l56rrByO6qdnRXkcgVkMlmhls+dvXGVstBoyvxvQiEZ/Xe5RpXLQCOK3uGNZDLIZDJkqDUoajEyGWCikKNcOXMAb7bz5dTBHOXLl/1v+xa9nKIuq88ySmJd2L7FWxe2b3GVI4NcnnOs0mhEoY+9UinS8cqsyMc8uVwPDVLKvNNhIT09HQBgbGysNd3ExAQpKSlFKlMmyxkGe9OmMTOSQx+XhJgVcRjuZSZ6+Klrffxc9gul6bEsyovtW7zYvsXFRCHXS/MqFHyN9OmdvsDR1NQUAPJczJiRkQEzszf/aWciIiJ6x8NC7umHBw8eaE1/8OABKlSoYIgqERERlTrvdFhwdnaGpaUljh8/Lk1LTU3F+fPn4evra8CaERERlR7v9DULxsbGCAkJwdSpU2FjY4P3338fU6ZMgYODA5o0aWLo6hEREZUK73RYAIABAwYgOzsbo0ePxvPnz+Hr64vFixdDqVQaumpERESlgkyIN7gvj4iIiEq9d/qaBSIiIip+DAtERESkE8MCERER6cSwQERERDoxLBAREZFODAtERESkE8MCERER6cSw8AKNRoNZs2bB398fNWrUQPfu3XH79u03KnPBggUIDQ3VUw3fbffv34eTk1Oef5s3bzZ01d55+fWzCxcuICQkBDVq1EDDhg2xfPlyA9Xu3Zdf+44ePTpPX27YsKGBavjuefz4McaMGYOAgAB4e3ujXbt2iI2NlZ6PiYlB69at4enpiWbNmmHnzp0GrC2989/gqE9z587F6tWrER4eDgcHB0yZMgXdunXDr7/+mudnsAti1apViIiIQM2aNYuhtu+eixcvwsTEBHv37tX6rfoyZcoYsFbvvvz6WXJyMjp37oyGDRti3LhxOHPmDMaNGwcLCwu0adPGgLV997xqP7506RJ69eqFkJAQaRp/FrngBg8ejIcPH2L69OmwtbXFihUr0LVrV2zZsgVCCPTs2ROdO3fGlClTsH//fgwdOhQ2NjaoU6eOoav+r8Sw8F+ZmZlYsmQJhgwZgsDAQADAjBkz4O/vjz/++AMtWrQocFn379/H2LFjcfz4cVSpUqV4KvwOunz5MqpUqQJ7e3tDV6VU0NXP1q9fD6VSifHjx8PIyAiOjo64efMmoqKiGBYKSFf7CiFw9epV9OjRA+XLlzdMBd9hN2/exJEjR7B69Wr4+PgAAH788UccOnQIv/76K5KSkuDk5IRBgwYBABwdHXH+/HksWrSIYcFAeBrivy5evIinT59qdUQrKyu4urri5MmThSrr//7v/6BUKrF9+3Z4enrqu6rvrEuXLsHR0dHQ1Sg1dPWz2NhY+Pn5wcjof58HateujX/++QeJiYlvu6rvJF3te+vWLTx79gxVq1Y1UO3ebdbW1oiKioK7u7s0TSaTQSaTITU1FbGxsXlCQe3atREXFwf+QoFhcGThvxISEgAAFStW1Jpub28vPVdQDRs25LnLfFy+fBnW1tbo0KEDbty4gQ8//BC9e/dGQECAoav2TtLVzxISEqBSqbSm5Y7o3Lt3D3Z2dsVev3edrva9fPkyAGDFihU4ePAg5HI5AgICMGjQIJ5WKwArKys0aNBAa9ru3btx8+ZNjBw5Elu2bIGDg4PW8/b29khPT0dycjJsbGzeZnUJHFmQpKenA0CeaxNMTEyQkZFhiCqVKtnZ2bh+/TpSUlLQv39/REVFoUaNGujRowdiYmIMXb1S5/nz5/n2ZQDsz3pw+fJlyOVy2NvbY/78+Rg+fDgOHz6MPn36QKPRGLp675xTp05hxIgRaNKkCQIDA/Ptv7mPMzMzDVHFfz2OLPyXqakpgJyOmPt/IOfAamZmZqhqlRpGRkY4fvw4FAqF1L7Vq1fHlStXsHjxYp6H1DNTU9M8B9XckGBubm6IKpUqvXv3Rvv27WFtbQ0AUKlUKF++PL766iv8/fffPP1YCHv37sWQIUPg7e2NqVOnAsgJti/339zHPB4bBkcW/iv39MODBw+0pj948AAVKlQwRJVKHQsLC60gBgDVqlXD/fv3DVSj0svBwSHfvgyA/VkP5HK5FBRyVatWDQAKfdry32zlypXo378/goKCMH/+fGn0q2LFivn2X3Nzc57mMRCGhf9ydnaGpaUljh8/Lk1LTU3F+fPn4evra8CalQ5XrlyBt7e3VvsCwLlz5/Dxxx8bqFall6+vL+Li4qBWq6Vpx44dw0cffQRbW1sD1qx0GDp0KDp16qQ17e+//wYA9ucCWr16NSZMmIAOHTpg+vTpWqcdatasiRMnTmjNf+zYMXh7e0Mu59uWIbDV/8vY2BghISGYOnUq/vOf/+DixYsYNGgQHBwc0KRJE0NX753n6OiIqlWrYvz48YiNjcW1a9fw888/48yZM+jdu7ehq1fqtGnTBmlpaRg1ahSuXr2KzZs3Izo6Gj179jR01UqFpk2bIiYmBrNnz8atW7dw4MABjBw5Ei1atOAdPwVw48YNTJo0CY0bN0bPnj2RmJiIhw8f4uHDh3jy5AlCQ0Px119/YerUqbh27RqWLFmC33//Hd26dTN01f+1eM3CCwYMGIDs7GyMHj0az58/h6+vLxYvXgylUmnoqr3z5HI55s+fj2nTpmHgwIFITU2Fq6srli5dmueqfXpztra2WLRoEcLCwhAcHIzy5ctj6NChCA4ONnTVSoVGjRohIiICUVFRWLhwIcqUKYOWLVti4MCBhq7aO2H37t3IysrCnj17sGfPHq3ngoODER4ejrlz52LKlClYtmwZKlWqhClTpvDaJgOSCd60SkRERDrwNAQRERHpxLBAREREOjEsEBERkU4MC0RERKQTwwIRERHpxLBAREREOjEsEBERkU78UiaiUiQ0NDTP1+TKZDKYm5ujSpUq+Pbbb/H555/rdZ2RkZGYPXs2Ll26pNdyiajkYFggKmVcXV0xduxY6bFarUZCQgKio6MxdOhQlCtXDg0aNDBgDYnoXcOwQFTKWFpaokaNGnmmBwQEoE6dOti8eTPDAhEVCsMC0b+EiYkJjI2NIZPJAACPHj1CZGQk9u/fj4cPH8Lc3By+vr4YMWIEKlWqBCDntMYHH3yADz/8EKtXr0ZSUhLc3NwwcuRIeHh45Lueu3fvon379rCxsUF0dDSsrKze2jYSUfFgWCAqZYQQyM7Olh6r1WrcuXMHc+bMwdOnT/H5559DCIGePXsiJSUFQ4YMgZ2dHS5duoSIiAiMHTsWixcvlpbfvXs3HB0dMXr0aAghMHnyZPTv3x/79u2DQqHQWvfDhw/RqVMnlCtXDkuXLmVQIColGBaISpmTJ0/Czc1Na5pMJoNKpcLMmTMRFBSE+/fvw8zMDMOGDUPNmjUBALVq1cKtW7ewbt06rWWzs7OxePFiWFpaAgCePn2KYcOG4cKFC6hevbo0X3JyMjp37gxTU1MsXboUZcuWLeYtJaK3hWGBqJRxc3PDuHHjAAAPHjxAREQEsrKyEBERgapVqwIAKlSogOXLl0MIgfj4eNy8eRPXr1/HqVOnkJmZqVXexx9/LAWF3GUBID09XWu+bt264cqVK1i2bBmsra2LcxOJ6C1jWCAqZSwsLODu7i499vT0RKtWrdClSxds3rwZNjY2AIDt27dj+vTpuHfvHsqVKwcXFxeYmprmKc/MzEzrsVye8/UsGo1Ga3p6ejoqVaqEadOmYd26ddJ8RPTu495MVMrZ2dlhzJgxuHfvHsLCwgAAsbGxGDZsGJo0aYKDBw/i+PHjiI6OzvcuioJatmwZxo4di7/++gvLly/XU+2JqCRgWCD6F2jWrBn8/f2xY8cOnDhxAqdPn4ZGo0H//v2l0wpqtRpHjx4FkHfUoCDKly+PgIAANG/eHDNnzkR8fLxet4GIDIdhgehfYuTIkVAqlZg4caJ0YeL48eNx7Ngx7N69G507d8bFixcBAM+ePXuj9cjlcq0vhiKidxvDAtG/RNWqVREaGopLly7h2rVrGDNmDE6fPo3u3bsjPDwc7733HmbPng0AiIuLK/J67O3tMXjwYBw+fBhbt27VU+2JyJBkQghh6EoQERFRycWRBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISKf/B6JaGBmKFrA8AAAAAElFTkSuQmCC",
+            "text/plain": [
+              "<Figure size 500x300 with 1 Axes>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
       "source": [
         "import matplotlib.pyplot as plt\n",
         "import seaborn as sns\n",
@@ -580,33 +742,30 @@
         "results[\"rank_shifted_right\"] = results[\"rank\"] + 0.1\n",
         "\n",
         "f, ax = plt.subplots(figsize=(5, 3))\n",
-        "sns.histplot(data=results.loc[results[\"score\"] == 1], x=\"rank_shifted_left\", color=\"skyblue\", label=\"Correct answer\", binwidth=1)\n",
-        "sns.histplot(data=results.loc[results[\"score\"] == 0], x=\"rank_shifted_right\", color=\"red\", label=\"False answer\", binwidth=1)\n",
+        "sns.histplot(data=results, x=\"rank_shifted_left\", color=\"skyblue\", label=\"Correct answer\", binwidth=1)\n",
         "\n",
         "ax.set_xticks([1, 5, 0, 10, 15, 20])\n",
         "ax.set_title(\"Rank of golden document (max means golden doc. wasn't retrieved)\")\n",
         "ax.set_xlabel(\"Rank\")\n",
         "ax.legend();\n"
-      ],
-      "metadata": {
-        "id": "SLn3s3n_MlpO"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "PZeTt7ijVKxo"
+      },
       "source": [
         "We see that retrieval works well overall: for 80% of questions, the golden document is within the top 5 documents. However, we also notice that approx. half the false answers come from instances where the golden document wasn't retrieved (`rank = top_k = 20`). This should be improved, e.g. by adding metadata to the documents such as their section headings, or altering the chunking strategy.\n",
         "\n",
         "There is also a non-negligible instance of false answers where the top document was retrieved. On closer inspection, many of these are due to the model phrasing its answers more verbosely than the (very laconic) golden documents. This highlights the importance of checking eval results before jumping to conclusions about model performance."
-      ],
-      "metadata": {
-        "id": "PZeTt7ijVKxo"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "4Q5i8EYDV_da"
+      },
       "source": [
         "## Conclusions\n",
         "\n",
@@ -616,19 +775,39 @@
         "2. How to build a custom retriever that leverages Cohere's `rerank`\n",
         "3. How to evaluate model performance against a predetermined set of golden QA pairs\n",
         "\n"
-      ],
-      "metadata": {
-        "id": "4Q5i8EYDV_da"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [],
+      "execution_count": null,
       "metadata": {
         "id": "UC2FKrkSWcPn"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": []
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.4"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/notebooks/guides/Creating_a_QA_bot_from_technical_documentation.ipynb
+++ b/notebooks/guides/Creating_a_QA_bot_from_technical_documentation.ipynb
@@ -54,20 +54,11 @@
             "/Users/neel/Library/Caches/pypoetry/virtualenvs/notebooks-WcB_wkWy-py3.11/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
             "  from .autonotebook import tqdm as notebook_tqdm\n"
           ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "True"
-            ]
-          },
-          "execution_count": 1,
-          "metadata": {},
-          "output_type": "execute_result"
         }
       ],
       "source": [
         "import os\n",
+        "import random\n",
         "import cohere\n",
         "import datasets\n",
         "from llama_index.core import StorageContext, VectorStoreIndex, load_index_from_storage\n",
@@ -81,12 +72,15 @@
         "from typing import List\n",
         "\n",
         "from dotenv import load_dotenv\n",
-        "load_dotenv()\n"
+        "load_dotenv()\n",
+        "\n",
+        "import warnings\n",
+        "warnings.filterwarnings('ignore')\n"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": 2,
       "metadata": {
         "id": "EECuI7OdIy8M"
       },
@@ -118,7 +112,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 3,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -139,7 +133,7 @@
         }
       ],
       "source": [
-        "# Set to true if you want to use only a small sample of the training data (~5000) rows\n",
+        "# Set to true if you want to use only a small sample of the training data (~10000) rows\n",
         "USE_SNIPPET = True\n",
         "\n",
         "data = datasets.load_dataset(\"sauravjoshi23/aws-documentation-chunked\")\n",
@@ -169,17 +163,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": 4,
       "metadata": {},
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Filter: 100%|██████████| 187147/187147 [00:00<00:00, 404111.70 examples/s]\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# -- to fix SSL error -- \n",
         "import ssl\n",
@@ -198,7 +184,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 5,
       "metadata": {
         "id": "tvgtKDBTG05h"
       },
@@ -207,7 +193,7 @@
         "# Create index in vector database, and persist it for later reuse\n",
         "# Note: this cell takes about ~2h on a MacBookPro\n",
         "\n",
-        "overwrite = True # only compute index if it doesn't exist\n",
+        "overwrite = False # only compute index if it doesn't exist\n",
         "path_index = Path(\".\") / \"aws-documentation_index_cohere\"\n",
         "\n",
         "# Select Cohere's new `embed-english-v3.0` as the engine to compute embeddings\n",
@@ -218,24 +204,17 @@
         " \n",
         "if not path_index.exists() or overwrite:\n",
         "    # Documents are prechunked. Keep them as-is for now\n",
-        "    documents = [\n",
-        "        # -- for indexing full dataset --\n",
-        "        # TextNode(\n",
-        "        #     text=sample[\"text\"],\n",
-        "        #     title=sample[\"source\"][stub_len:], # save source minus stub\n",
-        "        #     id_=sample[\"id\"],\n",
-        "        # ) for sample in data[\"train\"]\n",
-        "        # -- for testing on subset --\n",
-        "        TextNode(\n",
-        "            text=data[\"train\"][index][\"text\"],\n",
-        "            title=data[\"train\"][index][\"source\"][stub_len:],\n",
-        "            id_=data[\"train\"][index][\"id\"],\n",
-        "        ) for index in range(5_000)\n",
-        "    ]\n",
-        "\n",
-        "    # extend the sample of documents with the documents referenced in the QA pairs\n",
-        "    # test set\n",
+        "    # -- for indexing on a subset of full dataset --\n",
         "    if USE_SNIPPET:\n",
+        "        documents = [\n",
+        "            TextNode(\n",
+        "                text=data[\"train\"][index][\"text\"],\n",
+        "                title=data[\"train\"][index][\"source\"][stub_len:],\n",
+        "                id_=data[\"train\"][index][\"id\"],\n",
+        "            ) for index in range(5_000)\n",
+        "        ]\n",
+        "        # Extend the sample of documents with the documents referenced in the QA pairs\n",
+        "        # test set\n",
         "        documents.extend(\n",
         "            [\n",
         "                TextNode(\n",
@@ -245,10 +224,21 @@
         "                ) for data in golden_doc_data[\"train\"]\n",
         "            ]\n",
         "        )\n",
+        "    else:\n",
+        "        documents = [\n",
+        "            # -- for indexing full dataset --\n",
+        "            TextNode(\n",
+        "                text=sample[\"text\"],\n",
+        "                title=sample[\"source\"][stub_len:], # save source minus stub\n",
+        "                id_=sample[\"id\"],\n",
+        "            ) for sample in data[\"train\"]\n",
+        "        ]\n",
+        "    \n",
+        "    # Shuffle nodes in documents\n",
+        "    random.shuffle(documents)\n",
         "\n",
         "    index = VectorStoreIndex(documents, embed_model=embed_model)\n",
         "    index.storage_context.persist(path_index)\n",
-        "\n",
         "else:\n",
         "    storage_context = StorageContext.from_defaults(persist_dir=path_index)\n",
         "    index = load_index_from_storage(storage_context, embed_model=embed_model)\n"
@@ -273,7 +263,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 6,
       "metadata": {
         "id": "Wy_BGGbGG08w"
       },
@@ -313,7 +303,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": 7,
       "metadata": {
         "id": "ODihI1YCG0_5"
       },
@@ -353,7 +343,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": 8,
       "metadata": {
         "id": "7fH5mv2PG1DI"
       },
@@ -420,7 +410,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 9,
       "metadata": {
         "id": "rR67DcP5epAV"
       },
@@ -488,7 +478,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 10,
       "metadata": {
         "id": "tAg3MTOcMll4"
       },
@@ -497,7 +487,7 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "100%|██████████| 100/100 [09:19<00:00,  5.59s/it]\n"
+            "100%|██████████| 100/100 [09:04<00:00,  5.44s/it]\n"
           ]
         }
       ],
@@ -542,7 +532,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 11,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -570,7 +560,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 12,
       "metadata": {
         "id": "1qBvMpYmQDTK"
       },
@@ -596,7 +586,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 40,
+      "execution_count": 13,
       "metadata": {
         "id": "_F3V4E56Q1CE"
       },
@@ -605,7 +595,7 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "100%|██████████| 100/100 [06:41<00:00,  4.02s/it]\n"
+            "100%|██████████| 100/100 [03:43<00:00,  2.23s/it]\n"
           ]
         }
       ],
@@ -649,7 +639,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 20,
+      "execution_count": 14,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -664,7 +654,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": 26,
       "metadata": {
         "id": "1xksywOeQ1IJ"
       },
@@ -685,7 +675,27 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
+      "execution_count": 34,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "0.99"
+            ]
+          },
+          "execution_count": 34,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "results[results[\"rank\"] <= 5].shape[0] / results.shape[0]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 28,
       "metadata": {
         "id": "l8Z2w1ERSeHZ"
       },
@@ -694,7 +704,7 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Average score: 0.980\n"
+            "Average score: 0.970\n"
           ]
         }
       ],
@@ -715,14 +725,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 39,
+      "execution_count": 36,
       "metadata": {
         "id": "SLn3s3n_MlpO"
       },
       "outputs": [
         {
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgsAAAE/CAYAAADIXIDoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/TGe4hAAAACXBIWXMAAA9hAAAPYQGoP6dpAABPtklEQVR4nO3dd1gU18IG8Hd3WbooRcREEyNxaQICghUEjS1RE9QUFYy9a9QYezQWDMaGYsWGvdeoidFr7FjAkvjZS1RUVBBBFCm75/uDy1xXcAVcXCTv73l8cGdnzpw5e2b23TMzuzIhhAARERHRK8gNXQEiIiIq2RgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0Ylggegm/p4zo3VTc++6/+dhQqLAQGhoKJycnrX/Ozs7w9vZG69atsW3btmKpZGRkJJycnIql7J07dyIoKAjVq1fHmDFjimUduYYPH46GDRvqnGfz5s1wcnJCfHx8sdZFl4YNG2L48OEGW78hxcXFoUePHgWaNz4+HkFBQXj06FEx14qKS2hoKEJDQ3XOU5zHn4JycnJCZGSkQetQ0jg5OUnHqYSEBPTo0QN37twplnWlpqZi6NChiI2N1TlffHw8nJycsHnz5mKpR1G82HeSk5MRGBiI27dvF7oco8Iu4OrqirFjx0qP1Wo1EhISEB0djaFDh6JcuXJo0KBBoStiKOPHj0eVKlUQHh6OChUqGLo6ZGAbNmzAtWvXXjufEAIjRozAt99+Cxsbm7dQMyJ6mUwmAwAcPXoUBw4cKLb1XLhwAdu2bUObNm10zmdvb49169bhgw8+KLa6vAlra2t06tQJI0eOxPLly6X2K4hChwVLS0vUqFEjz/SAgADUqVMHmzdvfqfCwuPHj1GvXj3UqlXL0FWhd8iePXtw+fJlLF682NBVIfpXKl++POzt7Q1dDS3Gxsb5vj+WJO3bt8e8efOwZ88eNGnSpMDL6e2aBRMTExgbG2sllUePHmHcuHHSML+fnx/69u2rNcQeGhqKUaNGISoqCoGBgXB3d8c333yDv/7665Xrunv3LgIDA9G6dWukpqa+cr6///4bXbt2Ra1ateDt7Y1evXrhypUrAIDjx49LQ4tz5szROfSflpaGMWPGoE6dOvDy8sKgQYMQHR2dZ2hy165daN26Nby8vFCvXj2MGTMGKSkpr6yfRqPB3LlzERgYCE9PT/Tp0yff+S9fvoyePXvC29sb3t7e6Nu3r9YwUu62xMTEoEuXLvD09ES9evUwZcoUqNXqV64fAC5evIjOnTvDy8sLQUFB2L59e555MjIyMGfOHDRr1gzu7u5o0qQJoqKioNFotObbunUrgoOD4enpicDAQEybNg2ZmZkA8j8F8/KQ3YvbERoaCg8PDwQGBmLDhg148OAB+vXrBy8vLzRo0ADR0dFaZT1+/BhjxoxB3bp14e7ujq+++goxMTFa8zg5OWHVqlUYNWoU/Pz84OXlhe+++w6JiYlSHbds2YI7d+68dihxwYIFaNq0KYyNjbXKX7NmDYYPHw4fHx/4+flh4sSJeP78OSZPnozatWujVq1aGDVqFDIyMqTlXrefnDt3Dm5ublqnhpKSklCnTh107tz5ledRQ0NDMWbMGMydOxf+/v7w9PRE9+7dkZiYiE2bNqFx48bw8vJCp06d8vT9vXv3onXr1nB3d0e9evUwceJEPHv2LM887du3h5eXF6pXr45mzZph1apV0vMF7ZdHjhzBV199BS8vL/j6+qJ3796vHd158OABBg0aBD8/P/j6+mLMmDGYMWOGVh9Tq9VYtWoVWrZsKfWlqVOnarX9yzIyMvDzzz+jXr168PLywogRI/KdPzY2FiEhIfD09ISfnx+GDRumdTpq8+bNcHV1xdmzZ/H111/D3d0dQUFBBQqXJ06cwNdffw1PT080bdoUR48ezTPPkydP8PPPP+OTTz6Bu7s7WrRogY0bN2rNI4RAdHQ0mjdvDg8PDzRu3BiLFy8u8Hn3//znP3BycsL58+elaVu3boWTkxM2bNggTbtw4QKcnJxw+vRpAMDJkyfRtWtX+Pr6onr16mjYsCEiIyO1jhc7duxAq1at4OHhgdq1a2PIkCG4f/++9HzDhg0xa9YsTJ48GXXr1oWHhwe6du2Kf/75R5pHpVJJ++mIESMAAI0aNXrlKdTc/rh27VoEBQXB29sbR44cAaD79Tx+/Dg6duwIAOjYsaN02io0NBRDhgzBgAEDUKNGDXTu3Dnf0xB3797F4MGD4efnB09PT3z77bdabdq0aVMMGDAgT30///xz9O7dW3pckH2yIH3H2NgYTZs2xYIFC/Jtp1cShRASEiI6dOggsrKypH/Pnz8X165dE4MHDxYqlUrs27dPCCGERqMRbdu2FY0bNxY7duwQx44dE8uWLRNeXl6iS5cuWmX6+PiIr776SuzZs0f88ccfolGjRiIgIEBkZ2cLIYSYNWuWUKlUQgghHjx4IBo3biw+//xz8fjx41fWNSYmRri5uYkuXbqIvXv3ip07d4pWrVoJb29vcfXqVfHkyRNx+vRpoVKpxMiRI8Xp06dFRkZGvmWFhoaKmjVrilWrVok///xTdO/eXVSvXl2qkxBCzJkzRzg5OYlx48aJgwcPilWrVgk/Pz/RsmVLkZ6eLoQQYtiwYSIoKEhaJjw8XLi6uorIyEhx8OBBMWLECOHm5iZUKpW4ffu2EEKI69evCy8vL9GmTRvxxx9/iF27domWLVuKevXqicTERCGEEMeOHRMqlUrUrVtXzJ49Wxw9elRMmjRJqFQqsWbNmle2UUJCgvDx8RFt2rQRe/bsEVu2bBH+/v7C1dVVDBs2THodO3XqJGrUqCEWLVokDh8+LKZNmyZcXFzE6NGjpbJWrlwpVCqVGDVqlLT9np6e4scff8x324UQ4vbt20KlUolNmzZpbUft2rXFkiVLxNGjR0WnTp2Ei4uLaNq0qYiIiBBHjx4V/fr1EyqVSpw9e1YIIcTz589Fq1atRN26dcX69evF/v37Rf/+/YWrq6s4evSotD6VSiV8fHzE8OHDxaFDh8Tq1auFu7u7GDRokBBCiJs3b4ru3buLevXqidOnT4ukpKR82+3atWtCpVKJQ4cOaU1XqVTCy8tL/Pjjj+Lo0aMiLCxMqFQq0bRpU/Hdd9+JQ4cOicjISKFSqcTChQul9i3IfjJjxgyhUqmk7enTp4/w8/MTCQkJr3x9Q0JChJeXlwgJCREHDhwQ69atE25ubqJp06aiVatWYs+ePWL79u2iRo0aonv37tJy27dvFyqVSnz//ffiwIEDYvXq1cLX11d8++23QqPRCCGE+PPPP4VKpRITJ04UR48eFfv27RPdunUTKpVKnDlzRuv11NUvb926JTw8PMS4ceNETEyM2L17t2jatKlo2LChUKvV+W5XRkaGaNasmQgICBBbtmwRe/bsEV9++aWoXr26Vh8bOXKkcHNzExEREeLw4cMiKipKeHp6ii5dukjbERISIkJCQqRl+vfvL2rUqCGWLVsm9u/fL3r37i3tk7lOnDgh3NzcRNeuXcW+ffvEli1bRGBgoPjss8+kfX3Tpk3CyclJBAYGiujoaHH06FHpGHnw4MFXvmbnzp2Tyt6/f79YuXKlqFWrllCpVGLWrFlCCCHS09NFixYtRJ06dcSaNWvEwYMHxZgxY4RKpRLz5s2TygoPDxcuLi7il19+EUeOHBHz588Xzs7OYv78+a9c/4uePn0qqlevLvVVIXL2Y5VKJYYOHSpNmz9/vqhdu7ZQq9XiwoULwtXVVQwePFgcOnRIHDx4UPzwww9CpVKJHTt2CCGEiI2NFS4uLiIyMlIcO3ZMbN26VdSrV0906NBBKjMoKEj4+PiIHj16iP3794tt27YJPz8/8dVXX+WpZ1JSkrR//PHHH+LmzZv5bk9uf6xXr5747bffxJYtW8TTp09f+3o+efJEOr6tXLlSXLlyRQiR03dcXV3F8OHDxdGjR8Xhw4fzHNOSkpKEv7+/aNKkidi+fbvYs2ePCAkJETVq1BBXr14VQggxe/Zs4eHhIZ48eSLV9erVq0KlUonffvtNCFGwfbIgfSfXkSNHhEqlEtevXy9QXxBCiEKHBZVKleefk5OTaNmypbRhQuS8EYWGhoqTJ09qlTFhwgRRvXp1rTI9PT21GmrLli1CpVKJv//+Wwjxv7Dw6NEj8dlnn4mWLVuKR48e6axr27ZtxaeffioFDiGESElJEX5+fmLAgAHStPwa8kVHjx4VKpVK7N69W5qmVqtF8+bNpQPI48ePRfXq1aU3xlwnT56UOpgQ2m+YKSkpws3NTUyZMkVrma5du2qFhcGDB4u6detqtU9ycrLw8fER4eHhQoj/7QQzZszQKqthw4aiZ8+er9y28PBwUaNGDa03xTNnzgiVSiWFhf3792vt6LnmzJkjVCqVuHz5slCr1aJOnTqiT58+WvMsWrRIBAcHi8zMzEKFhRfbJLc+P/zwgzTt0aNHQqVSiaVLlwohhFi3bp3Wm5QQOW/CHTp0EK1bt5amqVQq0a5dO606DB8+XNSoUUN6nF89X7Zq1SqhUqlESkqK1nSVSiW+/PJL6XF2draoUaOGaNiwocjKypKmt2jRQvTu3VsIUfD9JDMzU7Rs2VI0bdpUbNq0SetA8iohISHC3d1dK1Tn9q9bt25J08aPHy98fHyEEDntFhAQILp27apVVu5+8OeffwohhFi4cKHUR3IlJycLlUolFixYIIQoWL/csWOHUKlUWqHn7NmzYvr06Vp9/kUbNmzQOj4IIcSTJ09ErVq1pNfuypUrWnXJtXXrVqFSqcT+/fulNsoNC5cvXxYqlUqsXr1aml+tVotPP/1UKyx8/fXXokWLFlrHluvXrwsXFxdpX899jdavXy/Nk5GRIdzd3cX48ePz3S4hcsJKQECAyMzMlKbt3LlT6ziV2/9OnTqltezIkSOFu7u7SE5OFikpKcLV1VWEhYVpzTNhwoQ8r60uXbp00QqtAQEBIjg4WGsf6dChg9QXtmzZIrp166YV9NRqtfDx8ZGOjwsWLBBeXl5aH872798vIiMjpTe+oKAgERQUpNXGuUE7v2N/bnvnHjfzk9sf58yZozW9IK9n7rLHjh2T5sl973pxO14+pk2fPl24u7uL+Ph4aZ6MjAzRqFEj0b9/fyFETmB2cnISW7ZskeaJiIgQNWvWFBkZGQXeJwvSd3KlpqYKlUolVq1a9cr2elmhT0O4ublh48aN2LhxI+bOnQuVSoUqVaogIiICzZo1k+arUKECli9fDh8fH8THx+PIkSNYsWIFTp06JQ1N5/r4449haWmptSwApKena83XrVs3XLlyBSNHjoS1tfUr6/js2TP8/fffaN68ORQKhTTdysoKQUFBOHHiRIG399ixY1Aqlfjkk0+kaXK5HJ9++qn0+MyZM8jMzESLFi20lq1Zsybef//9fNd35swZZGVlISgoSGt68+bN86zfz88PpqamyM7ORnZ2NiwtLVGzZs08Q0xeXl5ajx0cHPIMU70oLi4ONWrU0LpAz9PTE++99570+MSJEzAyMtJ6bQGgVatW0vM3btxAUlISGjdurDVP165dsXnzZiiVylfWIT8vboetra1Ur1y5r/2TJ08AADExMShfvjzc3NykNlKr1QgKCsK5c+e0Tu28fD7RwcEhTz97ndu3b8PKygpWVlY6665QKGBtbQ03NzcYGf3v8qBy5cpJdS/ofqJUKjF58mTEx8dj1KhRCA4OzvOa5MfR0RFly5aVHtvZ2cHa2hqVK1fOtz7Xr19HQkICGjZsKLVldnY2fH19YWlpKQ3bduvWDeHh4Xj69CnOnTuHXbt2ScOaL+/fuvqlp6cnTExM0LZtW4SFheHQoUNwdnbGoEGDtI4JLzp27BgqV66M6tWrS9MsLS219qXcfe6zzz7TWvazzz6DQqHA8ePH85Sbe6X7i6cy5HI5mjZtKj1OT0/H2bNn0aBBAwghpPapXLkyHB0dpfbJb9uNjY1hY2Pz2n3S399fa59p0qSJ1nHsxIkTeP/99/O0a6tWrZCRkYGzZ8/izJkzyM7OznNOevTo0Vi0aNEr1/+ywMBAxMXFITMzEzdu3EBCQgJ69eqFO3fu4M6dO0hLS8Pp06cRGBgIAPjiiy+wcOFCZGVl4eLFi9i9ezdmzZoFtVqNrKwsAICvry/S09PRokULTJs2DbGxsahfvz769eundRrb3d1da7sdHBwA5H1fKCwXFxfp/4V9PV9WtWpVrVORL4uJiYGLiwsqVKgglS2XyxEQECAdvytXrgxvb2/s2rVLWm7nzp1o1qwZjI2NC7xPFqTv5CpTpgysrKwKddddoS9wtLCwgLu7u/TY09MTrVq1QpcuXbB582atN57t27dj+vTpuHfvHsqVKwcXFxeYmprmKdPMzEzrsVyek2FePieenp6OSpUqYdq0aVi3bp0038uePHkCIQTs7OzyPGdnZycdGAsiOTkZ5cqVy7Ou3DcxANKbUWHWl7vMy6GnfPnyWo8fP36MXbt2aXWkXC9fhf9y28rlcp3nJ1NSUlCpUqU801+sQ0pKCqytrfN0uNx5njx5gsePHwPQbpM3kd+bxMt95EWPHz/Gw4cP4ebmlu/zDx8+lN4w8+trutooP2lpaa+sT351Nzc311leQfcTFxcXODk54dy5c3lC5qsUtj65r+W4ceMwbty4PM8/ePAAQM51FmPHjsXevXshk8nw4YcfombNmgDy3ouuq19WqlQJK1euRFRUFDZu3Ijly5fDysoK7du3x8CBA/O9Wjs5OTnfvpbfPvny/mRkZARra+si75OpqanQaDRYuHAhFi5cmKcMExOTAm97fnL3t/zq/OI8L28X8L/jT2pqqrSON71TJzAwEBMnTsSpU6dw/fp1fPTRRwgKCoK5uTlOnjwJc3NzyGQy1K9fHwDw/PlzTJgwAdu2bUN2djYqVaoELy8vGBkZSXXy8vJCVFQUoqOjsXTpUkRFRcHOzg69evXSuo21oO8LhfVi/y/s6/kyCwsLnc8/fvwYN2/efOWxKT09HWZmZvj8888xYcIEJCcnIz4+Hjdv3sSkSZOkMoDX75MF6TsvMjMzQ1pams76a5VV4Dlfwc7ODmPGjMF3332HsLAwTJs2DUBOSh82bBhCQ0PRtWtXabTgl19+QVxcXJHWtWzZMly4cAHdu3fH8uXL0alTp3znK1OmDGQymXTh2osePnyIcuXKFXidFSpUQHJyMjQajVZgSEpKkv6f+0aUmJiIqlWr5lnfi5/icuW+gElJSVrL5HaMF7elbt266Ny5c54yXvy0WhTW1tb5ttGLdShbtiySk5OhVqu1AkNuB7W2tpY+Yb/8fQPJyck4f/48vLy8IJPJ8lxsqesTVmGUKVMGVapUwdSpU/N9Pr9A9CZe9WZTFIXZT9atW4dz587B2dkZYWFhqFOnTr6jG28it7yhQ4fCz88vz/O5fX3IkCG4fv06oqOj4eXlBWNjY6Snp2P9+vWFXqeHhwdmz56NzMxMxMXFYd26dZg/fz6cnZ3zjLQBOfvkixe65cpvn3z48CHef/99aXpWVhaSk5PzPYDmTktMTNQaXXtxf7CwsIBMJkOnTp3yjFoAukNtQZQrVy7PPimE0BodK1u2LG7evJln2YcPH0rbkZ2dDSBnn3zx+HL37l3cunULPj4+BRrxq1y5MqpWrYqYmBjcuHEDfn5+UCqV8Pb2xvHjx6FQKKRPuAAQFhaG3bt3IyIiAnXr1pXemOvUqaNVrr+/P/z9/ZGeno5jx45h+fLlmDhxIjw9PeHh4VGQptKL4n49y5QpAz8/PwwdOjTf53NHJZo3b46JEydi7969uH79Ot5//334+PgAKPg+WZC+86LU1FSdI/Qv08vdEM2aNYO/vz927NghDf+dPn0aGo0G/fv3lw6AarVaGnopSjosX748AgIC0Lx5c8ycOfOVQyjm5uaoXr06fvvtN603qCdPnmD//v3Si1AQfn5+yM7Oxr59+6RpQgjs3btXeuzp6QljY2Ps2LFDa9nY2FjcvXsX3t7eecr18vKCqakpfv/9d63pf/75Z571X716FS4uLnB3d4e7uzuqV6+O6Oho7Nmzp8DbkZ/atWvj9OnTWlchX716VetOi9ztf7meuXdN+Pj4oGrVqrC2ts5T923btqFHjx7IysqChYUFkpOTta4sL2pofJmfnx/u3bsHW1tbqY3c3d1x5MgRLFq0KN9huFd51WjVi9577z08e/ZM550uBVXQ/eTOnTuYPHky2rZti/nz5+PJkycICwt74/W/rGrVqrC1tUV8fLxWW1aoUAHTpk2TruKOi4tDkyZNUKtWLemAd/DgQa06F0R0dDSCgoKQmZkJY2Nj1KlTBxMmTACQ88aWHz8/P8THx+PChQvStOfPn+PQoUNa8wA5w7kv2rlzJ9Rqdb7HgNq1awOAzn3S0tISrq6uuH79ulb7VKtWDZGRkfme3iiMOnXq4ODBg1pD7YcOHZKG8IGcYfw7d+5Idx/k2r59O5RKJTw8PODh4QGlUplnn1yyZAkGDx5cqH0iMDAQx48fR1xcnHSLea1atXD8+HEcOnRIa5Qrd55PPvlECgrnzp3Do0ePpH4xefJktGnTBkIImJmZISgoCMOGDQPw6tf8dQqy3+anoK9nYdrrRX5+frhx4wY++ugjrfK3bduGjRs3SuXmniL/z3/+g927d6NVq1bSqFpB98mC9J1cKSkpSE9P1wrFr/PGIwu5Ro4ciVatWmHixInYsmWLlA7Hjx+PNm3aICUlBatWrcLFixcB5HyqfNU5yYKs69ChQxg7duwrb0X6/vvv0bVrV/To0QPt27dHVlYWoqKikJmZib59+xZ4Xb6+vqhXrx5GjRolfeLYuHEjLl26JL2Y5cqVQ48ePTBnzhwolUoEBQUhPj4eM2fOxMcff4zg4OA85VpYWKBPnz6IiIiAmZkZateujQMHDuTZufv06YNvvvkGPXv2RLt27WBiYoJ169Zh7969mDVrViFaLa9vv/0WGzduRNeuXdG/f3+o1WrMmDFD6xNHQEAAatWqhdGjR+P+/ftwdnbGiRMnsHDhQgQHB+Pjjz8GAPTv3x/jx4+Hra0tGjZsiBs3bmDWrFno0KEDypYti6CgIKxYsQKjRo1C27ZtcfnyZSxdurTIO+GLWrdujZUrV6Jz587o1asXKlasiKNHj2LhwoUICQkp1DUTVlZWSExMxIEDB+Di4pLvfdz16tUDkHNgfN03cr5OQfYTCwsLjBo1CmZmZhg6dCjKli2LgQMHYtKkSWjatOkb1+FFCoUCgwYNwpgxY6BQKBAUFITU1FTMnTsX9+/fl4ZTPTw88Ouvv8LNzQ0ODg44deoUoqKiIJPJCnVOuXbt2pg6dSr69u2LkJAQKBQKrF27FsbGxq881dKiRQtERUWhb9+++O6772BlZYWlS5ciKSlJOvjl7nezZs1Ceno6fH19ceHCBcyePRu1atWCv79/nnI//PBDfP3115gxYways7Ph4uKCbdu24dKlS1rzDR48GD169MD333+PVq1aQa1WY8mSJTh79iz69OlT4G3PT9++fbF371507doV3bp1w6NHjxAREaHVh1u3bo3Vq1ejb9++GDBgACpVqoR9+/Zh06ZN6Nevn/RJtGPHjoiOjoaxsTH8/Pxw9uxZrFmzBkOHDoVcLkdaWhquXr2KDz74QOfpigYNGmDJkiUA/hfCateuLY0iv/g6eXh44LfffsOaNWvg6OiIixcvYt68eVr9onbt2li6dCmGDx+OVq1aISsrC4sWLUK5cuWkwFZYudu8Z88eBAQEwNHRscDLFuT1LFOmDABg//79KFu2LJydnQtUdqdOnbBt2zZ06tQJXbp0gbW1NXbt2oX169dLt3vmatWqFQYMGAC1Wo3PP/9cml7QfbIgfSdX7ge13NNHBaG3sFC1alWEhoZiyZIlWLNmDUJCQjBmzBgsXboUv//+O+zs7FCrVi3Mnj0bffv2RVxcXJG/vMne3h6DBw/G+PHjsXXrVnzxxRd55qlTpw6WLl2KWbNmYfDgwTA2NkbNmjUxefJkVKtWrVDrmzFjBsLDwzFt2jRkZ2ejUaNGaNeuHbZu3SrN079/f9jZ2WHlypVYt24dypUrh2bNmmHgwIGvPEfcs2dPmJubY9myZVi2bBm8vLwwbNgw/PTTT9I8zs7OWLVqFWbMmIGhQ4dCCAGVSoU5c+agUaNGhdqOl1lbW2PNmjUICwvD8OHDYWFhgW7dumldHyGTybBgwQLMmjUL0dHRePToESpVqoTBgwdrnRrp0KEDzM3NsXjxYqxbtw4ODg7o3r07unfvDiDnDXbYsGFYsWIFdu/eDTc3N8yePRvffPPNG20DkDOStGrVKkybNg1TpkzBkydP8P777+P7779Hly5dClVW69atceDAAelAnN9XP1euXBlubm44cODAG79R16pV67X7SXx8PGJiYhARESENOYaGhuLXX3/FmDFj4O3tXahTa6/z5ZdfwsLCAosWLcK6detgbm4Ob29vTJ06VTqlFh4ejgkTJkijAFWqVMG4ceOwffv2134l7oucnZ0xf/58zJkzB4MHD4ZarUb16tWxZMmSPKf0chkZGWHx4sUICwvDTz/9BCMjI7Rq1QrlypXDjRs3pPnCwsLw4YcfYtOmTVi4cCHs7e3RsWNH9OnT55WfRMeOHSvtxykpKfD390evXr0QEREhzVO/fn0sXrwYs2fPxoABA6BUKuHm5oalS5e+8RfyVKlSBStXrkR4eDgGDRoEW1tbDBs2DOHh4dI8ZmZmWLFiBaZNm4aZM2ciLS0NVatWRVhYGNq2bSvN98MPP8DW1hZr167FokWLUKlSJfz444/SPvd///d/6NixI37++We0bt36lXXy8fFBmTJlYGdnJ10r4ebmBktLS1SoUEHrNOvw4cORlZWFiIgIZGZmolKlSujduzeuXr2Kffv2Qa1Wo0GDBpg6dSqWLFkiXdTo4+OD5cuXF7kf16pVC3Xr1sW0adMQExODqKioAi9bkNezWrVqaNGiBVatWoVDhw7lGUV+lQoVKmDt2rWYNm0afvrpJ2RkZKBKlSp5XisgJ5SVKVMGlStXxkcffaT1XEH2yYL0nVwHDx6Eh4eH1im615GJwl7d9S9z584dnDlzBo0aNdK6WGnAgAG4ffs2tmzZYsDakaHs3r0bI0eOxMGDB197kRPp15UrV3D9+nU0adJE6wLItm3bwsHBAbNnzzZg7YhKtmfPnsHf3x+TJ0/WusvvdfQ2slBayeVyDB8+HI0aNULbtm2hUChw6NAh/PHHH/j5558NXT0ykCZNmmDp0qVYs2YNunXrZujq/Ks8e/YM3333Hdq3b4/GjRtDrVZj165dOHfuHIYMGWLo6hGVaGvXrkW1atUKPTLNkYUCOHbsGObMmYMLFy4gOzsbjo6O6Ny5c57vVaB/l1u3biEkJARbt27lj0m9Zb///jsWL16Ma9euQQgBV1dX9O7du1DnYIn+bR49eoQvvvgCK1aswIcfflioZRkWiIiISCe9/ZAUERERlU4MC0RERKQTwwIRERHpxLBAREREOvHWyZcIIaBWa6BWZ0OhMMr3h2wKXs6blVFasW2KF9u3eLF9i1dJaF+5XMbX9iUMCy/RaATu33+EhIRbcHD4AMbGeX/9ryAyM5+/cRmlFdumeLF9ixfbt3iVhPa1sbGAQsGw8CKehiAiIiKdGBaIiIhIJ4YFIiIi0olhgYiIiHRiWCAiIiKdeDcEEZUIGk3OLcslXXZ2lvRXJuPnLX17G+2rUBhBLudrVxgMC0RkUEIIpKY+Qnp6mqGrUiBCCMjlCqSkJPFe/GLwttrXzMwSVlY2fA0LiGGBiAwqNyhYWlrD2NikxB+8NRoNsrOzYGSk5KfTYlDc7SuEQGZmBtLSkgEAZcva6n0dpRHDQjGQy2VQKo1gZmYGpdIIRkZF6/AajYBGw18Qp9JLo1FLQcHS0srQ1SkQjUYDAFAqjRkWisHbaF9jYxMAQFpaMsqUsebrWAAMC3oml8tgbW0BuVwGe3vrNypLoxFITn7KwEClllqtBvC/gzfR25Lb59TqbMjlxgauTcnHsKBncrkMcrkMB26nIjEtHUqlMWTywg+rljVWIKBSGcjlMoYFKvVK+qkHKn3Y5wqHYaGYpGSokZieBWO1nENcREWQG7wNgacAibQxLBBRifPi6TxDKOopwOzsbGzevAG7d+/CrVs3YWJijGrVnBAa2hne3jWLqbZv5vr1a0hIuIe6desbuipUgjEsEFGJkzuqcDD+CVIy1W913UU9BZiRkYFBg/ri/v0EdOvWC9WreyAjIwM7d27HwIF9MHr0eDRp0qwYa140w4YNQrNmnzEskE4MC0RUYqVkqvHo+dsNC0W1ePF8XLt2BcuXr0OFCg7S9O+++x5Pn6Zh5swpqF8/AObm5gasZV5C8HQLvR7DAhHRG8rOzsaOHdvx6aettIJCrh49+iA4uC1MTHKuwE9NTcHChfNx5MhBPH78GE5OTujevY90qmLx4gU4fToOtra2iIk5iubNP4OTkwuWLVuMOnXq47fffoW3d038/PM0/PPPDcyePQNnz56Gubk5vL190a/fQNja2gHICQMbNqzFli0bcP/+fbz33vv49tsuaNy4Gdq2bYmEhHtYunQhTp+Ow+zZUXnqnpqainnzZiEm5giSkx+hTBkr+Ps3wHffDYGpqSlOnYrFoEF9ER4+DXPnzkJ8/G1UrPgeevfuD3//QADA7du3MGPGFPzf//0FjUbA3d0DffsOhKPjx+jSJQQeHp4YOPAHAMChQwcwatQPGD/+ZzRs2BgAEBk5A1evXsHMmXORlpaGOXNm4tChP5GVlQUnJxf06TMAzs6ur2y7QYOG6vcF/xfilXdERG/o7t14pKamwN3dM9/n7ezKw8XFDQqFAmq1GoMG9cNff53Gjz+Ox+LFK1C16scYPLgfLlz4P2mZM2dOwcbGDkuXrkLbtt8AAO7ciUdi4kMsWbIK3bv3QWLiQ/Tt2w2VKn2ARYtWYPLkCDx9moZevbogPT0dALB69XJERc1Bhw4dsWLFOnzxRWtMnDgWp07FYuHC5bC3r4BvvgnBpElT8q37pEk/4fLlSwgLm4K1a7dgwIDB+P33ndi+fbM0j1qtxty5szBw4A9YvnwdqlZ1xMSJY/Hs2TMAwNixI1G+fHksWrQCUVHRkMvlGDlyCACgXj1/nDx5XCorNvYEZDIZTp2Kk6bFxByGv38AhBD44YcBuHv3DiZPjkBU1DK4ubmjd++uuHz5os62ozfDkQUiojeUmpoKAChTpsxr5z1x4hguXbqA5cvXomrVjwEAQ4aMwIUL/4fVq1dgwoRwad6uXXvC0tISAPD332cBAJ06dcP771cCACxcOA/ly1fAwIFDpGXGjw/HZ581wp9/7kXz5i2wfv0afPllO7Ro8QUAoG3bb5CRkYHs7GxYW+d8IZGZmRmsrMrmW19f31qoUcMHjo45da1Y8T1s3LgO165d1Zqve/c+8PHxBQB8+2037N+/D9evX0X16h64ezcevr61ULHiezAyMsKIEWNw8+Y/0Gg0qF+/AZYuXYj79xNQoYIDYmOPo27d+jh9Oics3LkTj1u3bqJ+/QaIizuJc+f+xs6de6X69uzZF3//fRYbNqzFqFE/5dt29OYYFoiI3lC5cjlfwJaamvLaea9fvwpLS0spKAA59/x7enrjxIkYaZq1tU2+b3aVK1eW/n/58kXcuHENjRv7a82TmZmJf/65gZSUFCQlJcLNrbrW8x06fFuwDQMQHPwlDh8+iF27fkV8/C3cuHEd9+7dxYcfVtGar0qV/z3OrXdWVs6PQnXv3gezZk3Dli0b4eXljVq16uKTT5pCLpfDyckZ5cvb4+TJ46hZsxbu3r2D4cN/RN++3ZGUlIijRw+jWjUVHBwqYt++PRBCoE2bFnm2NyMj47VtR0XHsEBE9Ibee+992NjY4u+/z6JRoyZ5nv/nnxuYOXMq+vcf/MoLCoXQwMjof4fk3OsbXmZiYir9X6MR8Pauie+/H55nPkvLMlrlFYVGo8HQoQNx/fo1NG7cDI0aNYFK5YxffgnLM69SmfdbEHO3tU2br9Cw4SeIiTmCuLgTWLRoPpYtW4SlS1fDxsb2v6cijgEAXFzc4OzsgvLl7XHqVCxiYg6jfv0GUn0sLCywePHKfNavlP7/qrajouM1C0REb0gul+Ozz1ph164duH8/Ic/zq1cvx4UL51Gx4ntwdKyGtLQ0XL/+v2F8IQT++usMqlT5qFDrrVrVETdv/gN7+wqoVKkyKlWqDCsrK8yaNU0awbCzK48LF85rLTd69DBERk4HoPubDK9cuYxjx45iwoTJ6N27P5o0aY5KlSrjzp3bBb6LIjn5EaZPn4ysrCx8+mlL/PjjBCxbtgZJSUk4ffoUgJzrFuLiTiIu7qR0KsPbuyYOHz6I06fj4O/f4L/b+zGePn2KrKwsaXsrVaqMVauW4fDhA4VqOyochgUiIj349tuuqFz5A/Tp0w2//74Td+7E48KF/8OkSePw++87MWzYKJiZmcHPrzaqVVNh3LjROH06Dv/8cwPTp/+Ca9eu4ssv2xdqncHBbZGWlobx40fjypXLuHLlMsaMGYELF87jo48cAQAhId9i/fo12L17F+7ciceGDWtx6NB+6dO6mZkZ4uNv49GjpDzl29raQqFQYN++Pbh79w4uXjyPH38cjqSkJGRlZRaojmXKWCEm5ggmTw7DlSuXcOdOPLZt2wylUglnZxcAgI+PHzIyMnDgwD4pLPj4+OLPP/fCxsYWKpUzAKBWrTqoVk2FsWNH4NSpWMTH30Zk5HTs2vUrqlSpWqi2o8LhaQgiKrHKGivemXWamppi9uworFmzAitXLsP9+/dgYmIKlcoZkZEL4OnpBQBQKBSYPn0O5syJwMiRPyArKxPOzq6YOXMeqld3L9Q633vvfcyevQDz589Gnz5doVAo4O7uiVmz5sPaOuc6ijZtvkZGRgYWLZqPpKREVK78AcaP/xleXj4Aci54nDMnAtevX8OyZWu0yrezK49Ro8ZhyZIF2LJlA2xsbFG3bn18/XV7HD58sEB1NDIywpQpMzFnTgS++64Pnj9/jmrVVPjllwjpQk1jY2PUrFkLJ07EwM3NHYBAzZp+/70AMkAqS6FQYMaMuZg7dybGjBmO9PR0VKlSFWFhU6SQQcVDJviNHFrUag0SEpKQkHALDg4fwNjY9PULvcDISA5rawtsv5qMe6lPYWxsUqTfhrAxVaBl1XJITn6K7GxNoZcvyTIznxe5fen13qX2zcrKRFLSPdjaVtQ6512Sv+5Zo9EgKyuTP1FdTN5W+76q7wGAjY0FFAq+ti/iyAIRlTi5b9b8ISmikoFhgYhKJL5hE5UcHGchIiIinRgWiIiISCeGBSIiItKJYYGIDI43ZdHbxj5XOAwLRGQwCkXOdxpkZma8Zk4i/crtcwoFr/MvCLYSERmMXK6AmZkl0tKSAQDGxiY6v364JNBoNMjOzvmBJH7Pgv4Vd/sKIZCZmYG0tGSYmVnyNSwghgUiMigrKxsAkAJDSSeEgFqthkKhKPHB5l30ttrXzMxS6nv0eiU6LGRnZ2POnDnYunUrHj9+DFdXV/zwww+oUaMGAODChQsICwvDuXPnYGNjg06dOqFjx46GrTQRFYpMJkPZsrYoU8YaanW2oavzWllZGUhMvAcbG3solfx1Q317G+2rUBhxRKGQSnRYmDdvHjZs2IDw8HBUrlwZCxcuRLdu3bBr1y4olUp07twZDRs2xLhx43DmzBmMGzcOFhYWaNOmjaGrTkSFJJfLIZfn/ZnjkkaInK9fNzJS5vuzzPRm2L4lU4kOC3v37kWLFi1Qv359AMDw4cOxYcMGnDlzBjdu3IBSqcT48eNhZGQER0dH3Lx5E1FRUQwLREREelSix2FsbW3x559/Ij4+Hmq1GuvWrYOxsTGcnZ0RGxsLPz8/GBn9L+/Url0b//zzDxITEw1YayIiotKlRI8sjBo1Ct999x0aNWoEhUIBuVyOyMhIfPDBB0hISIBKpdKa397eHgBw79492NnZFWmdQgjpd9oL+nvt2ssbAbCQ7uEVQkCjKfyvRgqNXKpDVlbJP49bGG/SvvR6bN/ixfYtXiWhfYUwN9i6S6oSHRauXr2KMmXKYM6cOahQoQI2bNiAIUOGYOXKlXj+/DmMjbXPZ5mY5FwMk5FR9Hu21epsJCUlAID0tzDMzMxgb28t3fpT1A6fpcgJGImJ95Cenl6kMkq6orQvFRzbt3ixfYuXIdvXzs4KRkYKg62/JCqxYeHevXv4/vvvER0djZo1awIA3N3dcfXqVURGRsLU1BSZmdpvxLkhwdy86KlQoTCCra0DkpISYGvrUOgLbJTKnCY1MlICyIJSaVyk239yy7Gzq1gqRxaK2r70emzf4sX2LV4loX35RU15ldgWOXv2LLKysuDu7q413dPTEwcPHsR7772HBw8eaD2X+7hChQpFXq9MJpM6qFJpDGNj00Itb2Qkl8rJ/VuUW3RkcplUB5msxL5Mb6Qo7UsFx/YtXmzf4mXI9uX3Z+RVYi9wdHBwAABcunRJa/rly5dRpUoV+Pr6Ii4uDmq1Wnru2LFj+Oijj2Bra/tW60pERFSaldiw4OHhAR8fHwwbNgzHjh3DP//8g4iICMTExKBHjx5o06YN0tLSMGrUKFy9ehWbN29GdHQ0evbsaeiqExERlSoldnxbLpdj3rx5iIiIwIgRI5CSkgKVSoXo6Gh4enoCABYtWoSwsDAEBwejfPnyGDp0KIKDgw1ccyIiotKlxIYFAChbtizGjh2LsWPH5vu8h4cH1q1b95ZrRURE9O9SYk9DEBERUcnAsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTgwLREREpBPDAhEREenEsEBEREQ6MSwQERGRTiU+LGzduhWffvop3N3d8dlnn+G3336TnouPj0fPnj3h7e2N+vXrIyIiAmq12oC1JSIiKn1KdFjYtm0bRo0ahQ4dOmDnzp1o0aIFBg8ejNOnTyMrKwtdu3YFAKxduxY//fQT1qxZgzlz5hi41kRERKWLkaEr8CpCCMycORMdO3ZEhw4dAAC9e/dGbGwsTpw4gTt37uDu3btYv349ypYtC5VKhaSkJPzyyy/o1asXjI2NDbwFREREpUOJHVm4ceMG7ty5g5YtW2pNX7x4MXr27InY2Fi4ubmhbNmy0nO1a9dGWloaLly48LarS0REVGqV6LAAAM+ePUPXrl1Rp04dfPnll9i3bx8AICEhAQ4ODlrL2NvbAwDu3bv3ditLRERUipXY0xBpaWkAgGHDhqFfv34YMmQIdu/ejT59+mDp0qV4/vw5rKystJYxMTEBAGRkZBR5vUIIZGVlAoD0t3DLGwGwgBBCKk+j0RS+HI1cqkNWVnahly/J3qR96fXYvsWL7Vu8SkL7CmFusHWXVCU2LCiVSgBA165dERwcDABwcXHB+fPnsXTpUpiamiIzU7sz5YYEc/Oiv9BqdTaSkhIAQPpbGGZmZrC3t0Z2dhaAonf4LEVOwEhMvIf09PQilVHSFaV9qeDYvsWL7Vu8DNm+dnZWMDJSGGz9JVGJDQsVKlQAAKhUKq3pH3/8Mfbv3w8/Pz9cvnxZ67kHDx5oLVsUCoURbG0dkJSUAFtbByiVhbtQUqnMaVIjIyWALCiVxpDJZIWuR245dnYVS+XIQlHbl16P7Vu82L7FqyS0r0JRYt8aDabEtoibmxssLCxw9uxZ1KxZU5p++fJlfPDBB/D19cXWrVuRlpYGS0tLAMCxY8dgYWEBZ2fnIq9XJpNJHVSpNIaxsWmhljcykkvl5P6Vywt/aYhMLpPqIJOV2JfpjRSlfang2L7Fi+1bvAzZvkX5gFfaldgLHE1NTdGtWzfMmTMHO3bswK1btzBv3jwcOXIEnTt3xieffILy5ctj4MCBuHjxIvbu3Yvp06ejS5cuvG2SiIhIj0r0R9Y+ffrAzMwMM2bMwP379+Ho6IjIyEjUqlULALBo0SKMGzcOX331FcqWLYv27dujT58+Bq41ERFR6VKiwwIAdO7cGZ07d873uQ8//BBLlix5yzUiIiL6dymxpyGIiIioZHjrYSEhgbcbERERvUv0HhZcXFzw119/5ftcbGwsmjdvru9VEhERUTHSyzULS5YswbNnzwDkfGPhhg0bcPDgwTzznT59mncqEBERvWP0EhYyMjIwe/ZsADn3p27YsCHPPHK5HGXKlEHv3r31sUoiIiJ6S/QSFnr37i2FAGdnZ6xfvx4eHh76KJqIiIgMTO+3Tl68eFHfRRIREZEBFcv3LBw5cgR//vkn0tPT8/ziokwmw6RJk4pjtURERFQM9B4WlixZgl9++QUmJiawsbHJ8x3b/M5tIiKid4vew8LKlSvRsmVLhIWF8c4HIiKiUkDv37OQmJiItm3bMigQERGVEnoPC66urrhy5Yq+iyUiIiID0ftpiJEjR2LgwIEwNzeHp6cnzMzM8szz3nvv6Xu1REREVEz0HhbatWsHjUaDkSNHvvJixgsXLuh7tURERFRM9B4WJkyYwDseiIiIShG9h4XWrVvru0giIiIyIL2HhZMnT752Hl9fX32vloiIiIqJ3sNCaGgoZDIZhBDStJdPS/CaBSIioneH3sPC8uXL80x79uwZYmNjsW3bNkRGRup7lURERFSM9B4W/Pz88p0eGBgIc3NzzJs3DwsWLND3aomIiKiY6P1LmXSpWbMmTpw48TZXSURERG/orYaFffv2wcLC4m2ukoiIiN6Q3k9DdOzYMc80jUaDhIQE3LlzB927d9f3KomIiKgY6T0svHgXRC65XA6VSoWePXuiTZs2+l4lERERFSO9h4UVK1bou0giIiIyIL2HhVwHDx7EiRMnkJqaChsbG/j4+MDf37+4VkdERETFRO9hITMzE3369MHhw4ehUChgbW2N5ORkLFiwALVr18aCBQtgbGys79USERFRMdH73RCRkZGIi4vDL7/8gr/++guHDx/G2bNn8fPPP+PMmTOYN2+evldJRERExUjvYWHHjh3o168fWrVqBYVCAQAwMjLCF198gX79+uHXX3/V9yqJiIioGOk9LDx69Aiurq75Pufq6or79+/re5VERERUjPQeFj744APExcXl+9zJkydRsWJFfa+SiIiIipHeL3D85ptvEB4eDlNTU3z22Wews7NDYmIiduzYgYULF6Jfv376XiUREREVI72HhXbt2uH8+fOYOnUqpk2bJk0XQiA4OBg9evTQ9yqJiIioGBXLrZNhYWHo0qULTpw4gZSUFMhkMnzyySdwdHTU9+qIiIiomOntmoVLly6hTZs2WLp0KQDA0dER7dq1Q/v27TFz5kwMHjwYN27c0NfqiIiI6C3RS1iIj49Hx44dkZiYiI8++kjrOaVSiaFDh+Lx48do374974YgIiJ6x+glLERFRaFcuXLYsmULmjVrpvWcmZkZOnXqhI0bN8LExAQLFiwo0jpu3LgBLy8vbN68WZp24cIFhISEoEaNGmjYsCGWL1/+RttBREREeeklLMTExKBbt26wsbF55Tzly5dHly5dcOTIkUKXn5WVhSFDhuDZs2fStOTkZHTu3BkffPABNm3ahL59+2Lq1KnYtGlTkbaBiIiI8qeXCxwfPHiAKlWqvHY+lUqFhISEQpcfGRkJS0tLrWnr16+HUqnE+PHjYWRkBEdHR9y8eRNRUVH8GWwiIiI90svIgo2NDR48ePDa+ZKTk1G2bNlClX3y5EmsW7cO4eHhWtNjY2Ph5+cHI6P/5Z3atWvjn3/+QWJiYqHWQURERK+ml7Dg6+urdS3Bq2zduvWVXwWdn9TUVAwdOhSjR4/O882PCQkJcHBw0Jpmb28PALh3716B10FERES66eU0RGhoKNq1a4fw8HAMGjQIJiYmWs9nZmYiIiICBw8eRFRUVIHL/emnn+Dl5YWWLVvmee758+d5fuo6d70ZGRlF2IocQghkZWUCgPS3cMsbAbCAEEIqT6PRFL4cjVyqQ1ZWdqGXL8nepH3p9di+xYvtW7xKQvsKYW6wdZdUegkL7u7uGDFiBCZNmoRt27ahTp06qFSpEtRqNe7evYvjx48jOTkZ3333Hfz9/QtU5tatWxEbG/vKX6k0NTVFZqZ2Z8oNCebmRX+h1epsJCXlXFeR+7cwzMzMYG9vjezsLABF7/BZipyAkZh4D+np6UUqo6QrSvtSwbF9ixfbt3gZsn3t7KxgZKQw2PpLIr19g2OHDh3g7OyMxYsX4z//+Y/0xm1hYYH69eujS5cu8PT0LHB5mzZtQlJSEgIDA7Wmjx07Frt27YKDg0Oe6yRyH1eoUKHI26FQGMHW1gFJSQmwtXWAUmn8+oVeoFTmNKmRkRJAFpRKY8hkskLXI7ccO7uKpXJkoajtS6/H9i1ebN/iVRLaV6HQ+5cbv/P02iI+Pj7w8fEBkPNT1UZGRrCysipSWVOnTsXz58+1pjVp0gQDBgxAq1atsG3bNqxduxZqtRoKRU4CPHbsGD766CPY2toWeRtkMpnUQZVKYxgbmxZqeSMjuVRO7l+5vPCXhsjkMqkOMlnp7LhFaV8qOLZv8WL7Fi9Dtm9RPuCVdnr/iepcNjY2RQ4KQM7owIcffqj1DwBsbW1RoUIFtGnTBmlpaRg1ahSuXr2KzZs3Izo6Gj179tTXJhARERGKMSwUN1tbWyxatAg3btxAcHAwZs+ejaFDhyI4ONjQVSMiIipV3qnx7UuXLmk99vDwwLp16wxUGyIion+Hd3ZkgYiIiN4OhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp0YFoiIiEgnhgUiIiLSiWGBiIiIdGJYICIiIp1KdFh4/PgxxowZg4CAAHh7e6Ndu3aIjY2Vno+JiUHr1q3h6emJZs2aYefOnQasLRERUelUosPC4MGDcfr0aUyfPh2bNm2Ci4sLunbtiuvXr+PatWvo2bMn/P39sXnzZnz55ZcYOnQoYmJiDF1tIiKiUsXI0BV4lZs3b+LIkSNYvXo1fHx8AAA//vgjDh06hF9//RVJSUlwcnLCoEGDAACOjo44f/48Fi1ahDp16hiy6kRERKVKiR1ZsLa2RlRUFNzd3aVpMpkMMpkMqampiI2NzRMKateujbi4OAgh3nZ1iYiISq0SO7JgZWWFBg0aaE3bvXs3bt68iZEjR2LLli1wcHDQet7e3h7p6elITk6GjY1NkdYrhEBWViYASH8Lt7wRAAspsAghoNFoCl+ORi7VISsru9DLl2Rv0r70emzf4sX2LV4loX2FMDfYukuqEhsWXnbq1CmMGDECTZo0QWBgIJ4/fw5jY2OteXIfZ2YWvZOp1dlISkoAAOlvYZiZmcHe3hrZ2VkAit7hsxQ5ASMx8R7S09OLVEZJV5T2pYJj+xYvtm/xMmT72tlZwchIYbD1l0TvRFjYu3cvhgwZAm9vb0ydOhUAYGJikicU5D42MzMr8roUCiPY2jogKSkBtrYOUCqNX7/QC5TKnCY1MlICyIJSaQyZTFboeuSWY2dXsVSOLBS1fen12L7Fi+1bvEpC+yoU78Rb41tV4ltk5cqVCAsLQ7NmzTB58mRp9KBixYp48OCB1rwPHjyAubk5ypQpU+T1yWQyqYMqlcYwNjYt1PJGRnKpnNy/cnnhLw2RyWVSHWSyEv8yFUlR2pcKju1bvNi+xcuQ7VuUD3ilXYm9wBEAVq9ejQkTJqBDhw6YPn261mmHmjVr4sSJE1rzHzt2DN7e3kV6cyYiIqL8ldiPrDdu3MCkSZPQuHFj9OzZE4mJidJzpqamCA0NRXBwMKZOnYrg4GAcOHAAv//+OxYtWmTAWhMREZU+JTYs7N69G1lZWdizZw/27Nmj9VxwcDDCw8Mxd+5cTJkyBcuWLUOlSpUwZcoUfscCERGRnpXYsNCrVy/06tVL5zwBAQEICAh4SzUiIiL6d+LJfSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0MjJ0BUg3heLN85xGI6DRCD3UhoiI/o0YFkooM4UMQghYWZm9cVkajUBy8lMGBiIiKhKGhRLKWCGHTCbDoTtpeJyRXeRyyhorEFCpDORyGcMCEREVCcNCCZeSqcaj52pDV4OIiP7FeIEjERER6cSwQERERDoxLBAREZFODAtERESkE8MCERER6cSwQERERDq982FBo9Fg1qxZ8Pf3R40aNdC9e3fcvn3b0NUiIiIqNd75sDB37lysXr0aEyZMwNq1a6HRaNCtWzdkZmYaumpERESlwjv9pUyZmZlYsmQJhgwZgsDAQADAjBkz4O/vjz/++AMtWrQwbAVLkDf9jQn+vgQRFTe5XAal0ghmZmZQKo1gZFS04xaPV/r3ToeFixcv4unTp6hTp440zcrKCq6urjh58iTDAvT3GxP8fQkiKk5yuQzW1haQy2Wwt7d+o7J4vNK/dzosJCQkAAAqVqyoNd3e3l56rrByO6qdnRXkcgVkMlmhls+dvXGVstBoyvxvQiEZ/Xe5RpXLQCOK3uGNZDLIZDJkqDUoajEyGWCikKNcOXMAb7bz5dTBHOXLl/1v+xa9nKIuq88ySmJd2L7FWxe2b3GVI4NcnnOs0mhEoY+9UinS8cqsyMc8uVwPDVLKvNNhIT09HQBgbGysNd3ExAQpKSlFKlMmyxkGe9OmMTOSQx+XhJgVcRjuZSZ6+Klrffxc9gul6bEsyovtW7zYvsXFRCHXS/MqFHyN9OmdvsDR1NQUAPJczJiRkQEzszf/aWciIiJ6x8NC7umHBw8eaE1/8OABKlSoYIgqERERlTrvdFhwdnaGpaUljh8/Lk1LTU3F+fPn4evra8CaERERlR7v9DULxsbGCAkJwdSpU2FjY4P3338fU6ZMgYODA5o0aWLo6hEREZUK73RYAIABAwYgOzsbo0ePxvPnz+Hr64vFixdDqVQaumpERESlgkyIN7gvj4iIiEq9d/qaBSIiIip+DAtERESkE8MCERER6cSwQERERDoxLBAREZFODAtERESkE8MCERER6cSw8AKNRoNZs2bB398fNWrUQPfu3XH79u03KnPBggUIDQ3VUw3fbffv34eTk1Oef5s3bzZ01d55+fWzCxcuICQkBDVq1EDDhg2xfPlyA9Xu3Zdf+44ePTpPX27YsKGBavjuefz4McaMGYOAgAB4e3ujXbt2iI2NlZ6PiYlB69at4enpiWbNmmHnzp0GrC2989/gqE9z587F6tWrER4eDgcHB0yZMgXdunXDr7/+mudnsAti1apViIiIQM2aNYuhtu+eixcvwsTEBHv37tX6rfoyZcoYsFbvvvz6WXJyMjp37oyGDRti3LhxOHPmDMaNGwcLCwu0adPGgLV997xqP7506RJ69eqFkJAQaRp/FrngBg8ejIcPH2L69OmwtbXFihUr0LVrV2zZsgVCCPTs2ROdO3fGlClTsH//fgwdOhQ2NjaoU6eOoav+r8Sw8F+ZmZlYsmQJhgwZgsDAQADAjBkz4O/vjz/++AMtWrQocFn379/H2LFjcfz4cVSpUqV4KvwOunz5MqpUqQJ7e3tDV6VU0NXP1q9fD6VSifHjx8PIyAiOjo64efMmoqKiGBYKSFf7CiFw9epV9OjRA+XLlzdMBd9hN2/exJEjR7B69Wr4+PgAAH788UccOnQIv/76K5KSkuDk5IRBgwYBABwdHXH+/HksWrSIYcFAeBrivy5evIinT59qdUQrKyu4urri5MmThSrr//7v/6BUKrF9+3Z4enrqu6rvrEuXLsHR0dHQ1Sg1dPWz2NhY+Pn5wcjof58HateujX/++QeJiYlvu6rvJF3te+vWLTx79gxVq1Y1UO3ebdbW1oiKioK7u7s0TSaTQSaTITU1FbGxsXlCQe3atREXFwf+QoFhcGThvxISEgAAFStW1Jpub28vPVdQDRs25LnLfFy+fBnW1tbo0KEDbty4gQ8//BC9e/dGQECAoav2TtLVzxISEqBSqbSm5Y7o3Lt3D3Z2dsVev3edrva9fPkyAGDFihU4ePAg5HI5AgICMGjQIJ5WKwArKys0aNBAa9ru3btx8+ZNjBw5Elu2bIGDg4PW8/b29khPT0dycjJsbGzeZnUJHFmQpKenA0CeaxNMTEyQkZFhiCqVKtnZ2bh+/TpSUlLQv39/REVFoUaNGujRowdiYmIMXb1S5/nz5/n2ZQDsz3pw+fJlyOVy2NvbY/78+Rg+fDgOHz6MPn36QKPRGLp675xTp05hxIgRaNKkCQIDA/Ptv7mPMzMzDVHFfz2OLPyXqakpgJyOmPt/IOfAamZmZqhqlRpGRkY4fvw4FAqF1L7Vq1fHlStXsHjxYp6H1DNTU9M8B9XckGBubm6IKpUqvXv3Rvv27WFtbQ0AUKlUKF++PL766iv8/fffPP1YCHv37sWQIUPg7e2NqVOnAsgJti/339zHPB4bBkcW/iv39MODBw+0pj948AAVKlQwRJVKHQsLC60gBgDVqlXD/fv3DVSj0svBwSHfvgyA/VkP5HK5FBRyVatWDQAKfdry32zlypXo378/goKCMH/+fGn0q2LFivn2X3Nzc57mMRCGhf9ydnaGpaUljh8/Lk1LTU3F+fPn4evra8CalQ5XrlyBt7e3VvsCwLlz5/Dxxx8bqFall6+vL+Li4qBWq6Vpx44dw0cffQRbW1sD1qx0GDp0KDp16qQ17e+//wYA9ucCWr16NSZMmIAOHTpg+vTpWqcdatasiRMnTmjNf+zYMXh7e0Mu59uWIbDV/8vY2BghISGYOnUq/vOf/+DixYsYNGgQHBwc0KRJE0NX753n6OiIqlWrYvz48YiNjcW1a9fw888/48yZM+jdu7ehq1fqtGnTBmlpaRg1ahSuXr2KzZs3Izo6Gj179jR01UqFpk2bIiYmBrNnz8atW7dw4MABjBw5Ei1atOAdPwVw48YNTJo0CY0bN0bPnj2RmJiIhw8f4uHDh3jy5AlCQ0Px119/YerUqbh27RqWLFmC33//Hd26dTN01f+1eM3CCwYMGIDs7GyMHj0az58/h6+vLxYvXgylUmnoqr3z5HI55s+fj2nTpmHgwIFITU2Fq6srli5dmueqfXpztra2WLRoEcLCwhAcHIzy5ctj6NChCA4ONnTVSoVGjRohIiICUVFRWLhwIcqUKYOWLVti4MCBhq7aO2H37t3IysrCnj17sGfPHq3ngoODER4ejrlz52LKlClYtmwZKlWqhClTpvDaJgOSCd60SkRERDrwNAQRERHpxLBAREREOjEsEBERkU4MC0RERKQTwwIRERHpxLBAREREOjEsEBERkU78UiaiUiQ0NDTP1+TKZDKYm5ujSpUq+Pbbb/H555/rdZ2RkZGYPXs2Ll26pNdyiajkYFggKmVcXV0xduxY6bFarUZCQgKio6MxdOhQlCtXDg0aNDBgDYnoXcOwQFTKWFpaokaNGnmmBwQEoE6dOti8eTPDAhEVCsMC0b+EiYkJjI2NIZPJAACPHj1CZGQk9u/fj4cPH8Lc3By+vr4YMWIEKlWqBCDntMYHH3yADz/8EKtXr0ZSUhLc3NwwcuRIeHh45Lueu3fvon379rCxsUF0dDSsrKze2jYSUfFgWCAqZYQQyM7Olh6r1WrcuXMHc+bMwdOnT/H5559DCIGePXsiJSUFQ4YMgZ2dHS5duoSIiAiMHTsWixcvlpbfvXs3HB0dMXr0aAghMHnyZPTv3x/79u2DQqHQWvfDhw/RqVMnlCtXDkuXLmVQIColGBaISpmTJ0/Czc1Na5pMJoNKpcLMmTMRFBSE+/fvw8zMDMOGDUPNmjUBALVq1cKtW7ewbt06rWWzs7OxePFiWFpaAgCePn2KYcOG4cKFC6hevbo0X3JyMjp37gxTU1MsXboUZcuWLeYtJaK3hWGBqJRxc3PDuHHjAAAPHjxAREQEsrKyEBERgapVqwIAKlSogOXLl0MIgfj4eNy8eRPXr1/HqVOnkJmZqVXexx9/LAWF3GUBID09XWu+bt264cqVK1i2bBmsra2LcxOJ6C1jWCAqZSwsLODu7i499vT0RKtWrdClSxds3rwZNjY2AIDt27dj+vTpuHfvHsqVKwcXFxeYmprmKc/MzEzrsVye8/UsGo1Ga3p6ejoqVaqEadOmYd26ddJ8RPTu495MVMrZ2dlhzJgxuHfvHsLCwgAAsbGxGDZsGJo0aYKDBw/i+PHjiI6OzvcuioJatmwZxo4di7/++gvLly/XU+2JqCRgWCD6F2jWrBn8/f2xY8cOnDhxAqdPn4ZGo0H//v2l0wpqtRpHjx4FkHfUoCDKly+PgIAANG/eHDNnzkR8fLxet4GIDIdhgehfYuTIkVAqlZg4caJ0YeL48eNx7Ngx7N69G507d8bFixcBAM+ePXuj9cjlcq0vhiKidxvDAtG/RNWqVREaGopLly7h2rVrGDNmDE6fPo3u3bsjPDwc7733HmbPng0AiIuLK/J67O3tMXjwYBw+fBhbt27VU+2JyJBkQghh6EoQERFRycWRBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISCeGBSIiItKJYYGIiIh0YlggIiIinRgWiIiISKf/B6JaGBmKFrA8AAAAAElFTkSuQmCC",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgsAAAE/CAYAAADIXIDoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/TGe4hAAAACXBIWXMAAA9hAAAPYQGoP6dpAABN/0lEQVR4nO3dd1gU59oG8Htp0gQpAkmwJ4uAdMEWEDS2RE1QU1QwKvaWaDxYo1GDwdiIXUTFLrEbY2I0xhLFgrHEYy9RMSJSRFHq8n5/+DHHFVgpu+6C9++6csWdnXnnmXdnZm+mrUwIIUBERERUAj1tF0BERES6jWGBiIiIVGJYICIiIpUYFoiIiEglhgUiIiJSiWGBiIiIVGJYICIiIpUYFoiIiEglhgWiF/A5ZUSVk6a33dd531CmsBAaGgonJyel/xo2bAhvb2906dIFO3bs0EiR8+fPh5OTk0ba/vnnnxEUFIRGjRph0qRJGplHobFjx6JVq1Yqx9m6dSucnJyQmJio0VpUadWqFcaOHau1+WvTqVOnMGDAgFKNm5iYiKCgIKSlpWm4KtKU0NBQhIaGqhxHk/uf0nJycsL8+fO1WoOucXJykvZTSUlJGDBgAO7evauReT169Ajh4eFISEhQOV5iYiKcnJywdetWjdRRHs+vO+np6QgMDMSdO3fK3I5BWSdwcXHB5MmTpdcKhQJJSUmIjY1FeHg4atSogZYtW5a5EG2ZOnUq6tati8jISNjb22u7HNKyTZs24fr16y8dTwiBcePG4fPPP4e1tfUrqIyIXiSTyQAAR48excGDBzU2n4sXL2LHjh3o2rWryvHs7OwQFxeH2rVra6yWirCyskLv3r0xfvx4rF69Wuq/0ihzWDA3N4enp2eR4QEBAWjWrBm2bt1aqcLCw4cP0aJFCzRp0kTbpVAlsnfvXly5cgXLly/XdilEr6WaNWvCzs5O22UoMTIyKvb7UZf06NEDixcvxt69e9G2bdtST6e2axaqVasGIyMjpaSSlpaGKVOmSIf5/fz8MHToUKVD7KGhoZgwYQKio6MRGBgINzc3fPbZZzh37lyJ8/r3338RGBiILl264NGjRyWO9/fffyMsLAxNmjSBt7c3Bg0ahKtXrwIAjh8/Lh1aXLhwocpD/5mZmZg0aRKaNWsGLy8vjBw5ErGxsUUOTe7evRtdunSBl5cXWrRogUmTJiEjI6PE+goKCrBo0SIEBgbCw8MDQ4YMKXb8K1euYODAgfD29oa3tzeGDh2qdBipcFni4+PRt29feHh4oEWLFpg5cyYUCkWJ8weAS5cuoU+fPvDy8kJQUBB27txZZJycnBwsXLgQ7du3h5ubG9q2bYvo6GgUFBQojbd9+3YEBwfDw8MDgYGBmD17NnJzcwEUfwrmxUN2zy9HaGgo3N3dERgYiE2bNiE5ORnDhg2Dl5cXWrZsidjYWKW2Hj58iEmTJqF58+Zwc3PDJ598gvj4eKVxnJycsG7dOkyYMAF+fn7w8vLCF198gZSUFKnGbdu24e7duy89lLh06VK0a9cORkZGSu1v2LABY8eOhY+PD/z8/PDtt98iOzsbM2bMQNOmTdGkSRNMmDABOTk50nQv207Onz8PV1dXpVNDqampaNasGfr06VPiedTQ0FBMmjQJixYtgr+/Pzw8PNC/f3+kpKRgy5YtaNOmDby8vNC7d+8i6/6+ffvQpUsXuLm5oUWLFvj222/x9OnTIuP06NEDXl5eaNSoEdq3b49169ZJ75d2vTxy5Ag++eQTeHl5wdfXF4MHD37p0Z3k5GSMHDkSfn5+8PX1xaRJkzB37lyldUyhUGDdunXo1KmTtC7NmjVLqe9flJOTg++++w4tWrSAl5cXxo0bV+z4CQkJCAkJgYeHB/z8/DBmzBil01Fbt26Fi4sLzp49i08//RRubm4ICgoqVbg8ceIEPv30U3h4eKBdu3Y4evRokXEeP36M7777Du+99x7c3NzQsWNHbN68WWkcIQRiY2PRoUMHuLu7o02bNli+fHmpz7v//vvvcHJywoULF6Rh27dvh5OTEzZt2iQNu3jxIpycnHD69GkAwMmTJxEWFgZfX180atQIrVq1wvz585X2F7t27ULnzp3h7u6Opk2bYvTo0bh//770fqtWrTBv3jzMmDEDzZs3h7u7O8LCwvDPP/9I48jlcmk7HTduHACgdevWJZ5CLVwfN27ciKCgIHh7e+PIkSMAVH+ex48fR69evQAAvXr1kk5bhYaGYvTo0RgxYgQ8PT3Rp0+fYk9D/Pvvvxg1ahT8/Pzg4eGBzz//XKlP27VrhxEjRhSp98MPP8TgwYOl16XZJkuz7hgZGaFdu3ZYunRpsf1UIlEGISEhomfPniIvL0/6Lzs7W1y/fl2MGjVKyOVysX//fiGEEAUFBaJbt26iTZs2YteuXeLYsWNi1apVwsvLS/Tt21epTR8fH/HJJ5+IvXv3it9++020bt1aBAQEiPz8fCGEEPPmzRNyuVwIIURycrJo06aN+PDDD8XDhw9LrDU+Pl64urqKvn37in379omff/5ZdO7cWXh7e4tr166Jx48fi9OnTwu5XC7Gjx8vTp8+LXJycoptKzQ0VDRu3FisW7dO/PHHH6J///6iUaNGUk1CCLFw4ULh5OQkpkyZIg4dOiTWrVsn/Pz8RKdOnURWVpYQQogxY8aIoKAgaZrIyEjh4uIi5s+fLw4dOiTGjRsnXF1dhVwuF3fu3BFCCHHjxg3h5eUlunbtKn777Texe/du0alTJ9GiRQuRkpIihBDi2LFjQi6Xi+bNm4sFCxaIo0ePiunTpwu5XC42bNhQYh8lJSUJHx8f0bVrV7F3716xbds24e/vL1xcXMSYMWOkz7F3797C09NTxMTEiD///FPMnj1bODs7i4kTJ0ptrV27VsjlcjFhwgRp+T08PMTXX39d7LILIcSdO3eEXC4XW7ZsUVqOpk2bihUrVoijR4+K3r17C2dnZ9GuXTsRFRUljh49KoYNGybkcrk4e/asEEKI7Oxs0blzZ9G8eXPx448/igMHDojhw4cLFxcXcfToUWl+crlc+Pj4iLFjx4rDhw+L9evXCzc3NzFy5EghhBC3bt0S/fv3Fy1atBCnT58Wqampxfbb9evXhVwuF4cPH1YaLpfLhZeXl/j666/F0aNHRUREhJDL5aJdu3biiy++EIcPHxbz588XcrlcLFu2TOrf0mwnc+fOFXK5XFqeIUOGCD8/P5GUlFTi5xsSEiK8vLxESEiIOHjwoIiLixOurq6iXbt2onPnzmLv3r1i586dwtPTU/Tv31+abufOnUIul4uvvvpKHDx4UKxfv174+vqKzz//XBQUFAghhPjjjz+EXC4X3377rTh69KjYv3+/6Nevn5DL5eLMmTNKn6eq9fL27dvC3d1dTJkyRcTHx4s9e/aIdu3aiVatWgmFQlHscuXk5Ij27duLgIAAsW3bNrF3717x8ccfi0aNGimtY+PHjxeurq4iKipK/PnnnyI6Olp4eHiIvn37SssREhIiQkJCpGmGDx8uPD09xapVq8SBAwfE4MGDpW2y0IkTJ4Srq6sICwsT+/fvF9u2bROBgYHigw8+kLb1LVu2CCcnJxEYGChiY2PF0aNHpX3koUOHSvzMzp8/L7V94MABsXbtWtGkSRMhl8vFvHnzhBBCZGVliY4dO4pmzZqJDRs2iEOHDolJkyYJuVwuFi9eLLUVGRkpnJ2dxffffy+OHDkilixZIho2bCiWLFlS4vyf9+TJE9GoUSNpXRXi2XYsl8tFeHi4NGzJkiWiadOmQqFQiIsXLwoXFxcxatQocfjwYXHo0CHxn//8R8jlcrFr1y4hhBAJCQnC2dlZzJ8/Xxw7dkxs375dtGjRQvTs2VNqMygoSPj4+IgBAwaIAwcOiB07dgg/Pz/xySefFKkzNTVV2j5+++03cevWrWKXp3B9bNGihfjll1/Etm3bxJMnT176eT5+/Fjav61du1ZcvXpVCPFs3XFxcRFjx44VR48eFX/++WeRfVpqaqrw9/cXbdu2FTt37hR79+4VISEhwtPTU1y7dk0IIcSCBQuEu7u7ePz4sVTrtWvXhFwuF7/88osQonTbZGnWnUJHjhwRcrlc3Lhxo1TrghBClDksyOXyIv85OTmJTp06SQsmxLMvotDQUHHy5EmlNqZNmyYaNWqk1KaHh4dSR23btk3I5XLx999/CyH+FxbS0tLEBx98IDp16iTS0tJU1tqtWzfx/vvvS4FDCCEyMjKEn5+fGDFihDSsuI583tGjR4VcLhd79uyRhikUCtGhQwdpB/Lw4UPRqFEj6Yux0MmTJ6UVTAjlL8yMjAzh6uoqZs6cqTRNWFiYUlgYNWqUaN68uVL/pKenCx8fHxEZGSmE+N9GMHfuXKW2WrVqJQYOHFjiskVGRgpPT0+lL8UzZ84IuVwuhYUDBw4obeiFFi5cKORyubhy5YpQKBSiWbNmYsiQIUrjxMTEiODgYJGbm1umsPB8nxTW85///EcalpaWJuRyuVi5cqUQQoi4uDilLykhnn0J9+zZU3Tp0kUaJpfLRffu3ZVqGDt2rPD09JReF1fni9atWyfkcrnIyMhQGi6Xy8XHH38svc7Pzxeenp6iVatWIi8vTxresWNHMXjwYCFE6beT3Nxc0alTJ9GuXTuxZcsWpR1JSUJCQoSbm5tSqC5cv27fvi0Nmzp1qvDx8RFCPOu3gIAAERYWptRW4Xbwxx9/CCGEWLZsmbSOFEpPTxdyuVwsXbpUCFG69XLXrl1CLpcrhZ6zZ8+KOXPmKK3zz9u0aZPS/kEIIR4/fiyaNGkifXZXr15VqqXQ9u3bhVwuFwcOHJD6qDAsXLlyRcjlcrF+/XppfIVCId5//32lsPDpp5+Kjh07Ku1bbty4IZydnaVtvfAz+vHHH6VxcnJyhJubm5g6dWqxyyXEs7ASEBAgcnNzpWE///yz0n6qcP3766+/lKYdP368cHNzE+np6SIjI0O4uLiIiIgIpXGmTZtW5LNVpW/fvkqhNSAgQAQHByttIz179pTWhW3btol+/fopBT2FQiF8fHyk/ePSpUuFl5eX0h9nBw4cEPPnz5e++IKCgkRQUJBSHxcG7eL2/YX9XbjfLE7h+rhw4UKl4aX5PAunPXbsmDRO4XfX88vx4j5tzpw5ws3NTSQmJkrj5OTkiNatW4vhw4cLIZ4FZicnJ7Ft2zZpnKioKNG4cWORk5NT6m2yNOtOoUePHgm5XC7WrVtXYn+9qMynIVxdXbF582Zs3rwZixYtglwuR926dREVFYX27dtL49nb22P16tXw8fFBYmIijhw5gjVr1uCvv/6SDk0Xevvtt2Fubq40LQBkZWUpjdevXz9cvXoV48ePh5WVVYk1Pn36FH///Tc6dOgAfX19abiFhQWCgoJw4sSJUi/vsWPHYGhoiPfee08apqenh/fff196febMGeTm5qJjx45K0zZu3BhvvfVWsfM7c+YM8vLyEBQUpDS8Q4cORebv5+cHY2Nj5OfnIz8/H+bm5mjcuHGRQ0xeXl5Krx0cHIocpnreqVOn4OnpqXSBnoeHB958803p9YkTJ2BgYKD02QJA586dpfdv3ryJ1NRUtGnTRmmcsLAwbN26FYaGhiXWUJznl8PGxkaqq1DhZ//48WMAQHx8PGrWrAlXV1epjxQKBYKCgnD+/HmlUzsvnk90cHAosp69zJ07d2BhYQELCwuVtevr68PKygqurq4wMPjf5UE1atSQai/tdmJoaIgZM2YgMTEREyZMQHBwcJHPpDgNGjSApaWl9NrW1hZWVlaoVatWsfXcuHEDSUlJaNWqldSX+fn58PX1hbm5uXTYtl+/foiMjMSTJ09w/vx57N69Wzqs+eL2rWq99PDwQLVq1dCtWzdERETg8OHDaNiwIUaOHKm0T3jesWPHUKtWLTRq1EgaZm5urrQtFW5zH3zwgdK0H3zwAfT19XH8+PEi7RZe6f78qQw9PT20a9dOep2VlYWzZ8+iZcuWEEJI/VOrVi00aNBA6p/ilt3IyAjW1tYv3Sb9/f2Vtpm2bdsq7cdOnDiBt956q0i/du7cGTk5OTh79izOnDmD/Pz8IuekJ06ciJiYmBLn/6LAwECcOnUKubm5uHnzJpKSkjBo0CDcvXsXd+/eRWZmJk6fPo3AwEAAwEcffYRly5YhLy8Ply5dwp49ezBv3jwoFArk5eUBAHx9fZGVlYWOHTti9uzZSEhIwLvvvothw4YpncZ2c3NTWm4HBwcARb8XysrZ2Vn6d1k/zxfVr19f6VTki+Lj4+Hs7Ax7e3upbT09PQQEBEj771q1asHb2xu7d++Wpvv555/Rvn17GBkZlXqbLM26U6h69eqwsLAo0113Zb7A0czMDG5ubtJrDw8PdO7cGX379sXWrVuVvnh27tyJOXPm4N69e6hRowacnZ1hbGxcpE0TExOl13p6zzLMi+fEs7Ky4OjoiNmzZyMuLk4a70WPHz+GEAK2trZF3rO1tZV2jKWRnp6OGjVqFJlX4ZcYAOnLqCzzK5zmxdBTs2ZNpdcPHz7E7t27lVakQi9ehf9i3+rp6ak8P5mRkQFHR8ciw5+vISMjA1ZWVkVWuMJxHj9+jIcPHwJQ7pOKKO5L4sV15HkPHz7EgwcP4OrqWuz7Dx48kL4wi1vXVPVRcTIzM0usp7jaTU1NVbZX2u3E2dkZTk5OOH/+fJGQWZKy1lP4WU6ZMgVTpkwp8n5ycjKAZ9dZTJ48Gfv27YNMJkOdOnXQuHFjAEXvRVe1Xjo6OmLt2rWIjo7G5s2bsXr1alhYWKBHjx748ssvi71aOz09vdh1rbht8sXtycDAAFZWVuXeJh89eoSCggIsW7YMy5YtK9JGtWrVSr3sxSnc3oqr+flxXlwu4H/7n0ePHknzqOidOoGBgfj222/x119/4caNG6hXrx6CgoJgamqKkydPwtTUFDKZDO+++y4AIDs7G9OmTcOOHTuQn58PR0dHeHl5wcDAQKrJy8sL0dHRiI2NxcqVKxEdHQ1bW1sMGjRI6TbW0n4vlNXz639ZP88XmZmZqXz/4cOHuHXrVon7pqysLJiYmODDDz/EtGnTkJ6ejsTERNy6dQvTp0+X2gBevk2WZt15nomJCTIzM1XWr9RWqccsga2tLSZNmoQvvvgCERERmD17NoBnKX3MmDEIDQ1FWFiYdLTg+++/x6lTp8o1r1WrVuHixYvo378/Vq9ejd69exc7XvXq1SGTyaQL15734MED1KhRo9TztLe3R3p6OgoKCpQCQ2pqqvTvwi+ilJQU1K9fv8j8nv8rrlDhB5iamqo0TeGK8fyyNG/eHH369CnSxvN/rZaHlZVVsX30fA2WlpZIT0+HQqFQCgyFK6iVlZX0F/aLzxtIT0/HhQsX4OXlBZlMVuRiS1V/YZVF9erVUbduXcyaNavY94sLRBVR0pdNeZRlO4mLi8P58+fRsGFDREREoFmzZsUe3aiIwvbCw8Ph5+dX5P3CdX306NG4ceMGYmNj4eXlBSMjI2RlZeHHH38s8zzd3d2xYMEC5Obm4tSpU4iLi8OSJUvQsGHDIkfagGfb5PMXuhUqbpt88OAB3nrrLWl4Xl4e0tPTi92BFg5LSUlROrr2/PZgZmYGmUyG3r17FzlqAagOtaVRo0aNItukEELp6JilpSVu3bpVZNoHDx5Iy5Gfnw/g2Tb5/P7l33//xe3bt+Hj41OqI361atVC/fr1ER8fj5s3b8LPzw+Ghobw9vbG8ePHoa+vL/2FCwARERHYs2cPoqKi0Lx5c+mLuVmzZkrt+vv7w9/fH1lZWTh27BhWr16Nb7/9Fh4eHnB3dy9NV6mFpj/P6tWrw8/PD+Hh4cW+X3hUokOHDvj222+xb98+3LhxA2+99RZ8fHwAlH6bLM2687xHjx6pPEL/IrXcDdG+fXv4+/tj165d0uG/06dPo6CgAMOHD5d2gAqFQjr0Up50WLNmTQQEBKBDhw744YcfSjyEYmpqikaNGuGXX35R+oJ6/PgxDhw4IH0IpeHn54f8/Hzs379fGiaEwL59+6TXHh4eMDIywq5du5SmTUhIwL///gtvb+8i7Xp5ecHY2Bi//vqr0vA//vijyPyvXbsGZ2dnuLm5wc3NDY0aNUJsbCz27t1b6uUoTtOmTXH69Gmlq5CvXbumdKdF4fK/WGfhXRM+Pj6oX78+rKysitS+Y8cODBgwAHl5eTAzM0N6errSleXlDY0v8vPzw71792BjYyP1kZubG44cOYKYmJhiD8OVpKSjVc9788038fTpU5V3upRWabeTu3fvYsaMGejWrRuWLFmCx48fIyIiosLzf1H9+vVhY2ODxMREpb60t7fH7Nmzpau4T506hbZt26JJkybSDu/QoUNKNZdGbGwsgoKCkJubCyMjIzRr1gzTpk0D8OyLrTh+fn5ITEzExYsXpWHZ2dk4fPiw0jjAs8O5z/v555+hUCiK3Qc0bdoUAFRuk+bm5nBxccGNGzeU+uedd97B/Pnziz29URbNmjXDoUOHlA61Hz58WDqEDzw7jH/37l3p7oNCO3fuhKGhIdzd3eHu7g5DQ8Mi2+SKFSswatSoMm0TgYGBOH78OE6dOiXdYt6kSRMcP34chw8fVjrKVTjOe++9JwWF8+fPIy0tTVovZsyYga5du0IIARMTEwQFBWHMmDEASv7MX6Y0221xSvt5lqW/nufn54ebN2+iXr16Su3v2LEDmzdvltotPEX++++/Y8+ePejcubN0VK2022Rp1p1CGRkZyMrKUgrFL1PhIwuFxo8fj86dO+Pbb7/Ftm3bpHQ4depUdO3aFRkZGVi3bh0uXboE4NlflSWdkyzNvA4fPozJkyeXeCvSV199hbCwMAwYMAA9evRAXl4eoqOjkZubi6FDh5Z6Xr6+vmjRogUmTJgg/cWxefNmXL58Wfowa9SogQEDBmDhwoUwNDREUFAQEhMT8cMPP+Dtt99GcHBwkXbNzMwwZMgQREVFwcTEBE2bNsXBgweLbNxDhgzBZ599hoEDB6J79+6oVq0a4uLisG/fPsybN68MvVbU559/js2bNyMsLAzDhw+HQqHA3Llzlf7iCAgIQJMmTTBx4kTcv38fDRs2xIkTJ7Bs2TIEBwfj7bffBgAMHz4cU6dOhY2NDVq1aoWbN29i3rx56NmzJywtLREUFIQ1a9ZgwoQJ6NatG65cuYKVK1eWeyN8XpcuXbB27Vr06dMHgwYNwhtvvIGjR49i2bJlCAkJKdM1ExYWFkhJScHBgwfh7Oxc7H3cLVq0APBsx/iyJ3K+TGm2EzMzM0yYMAEmJiYIDw+HpaUlvvzyS0yfPh3t2rWrcA3P09fXx8iRIzFp0iTo6+sjKCgIjx49wqJFi3D//n3pcKq7uzt++uknuLq6wsHBAX/99Reio6Mhk8nKdE65adOmmDVrFoYOHYqQkBDo6+tj48aNMDIyKvFUS8eOHREdHY2hQ4fiiy++gIWFBVauXInU1FRp51e43c2bNw9ZWVnw9fXFxYsXsWDBAjRp0gT+/v5F2q1Tpw4+/fRTzJ07F/n5+XB2dsaOHTtw+fJlpfFGjRqFAQMG4KuvvkLnzp2hUCiwYsUKnD17FkOGDCn1shdn6NCh2LdvH8LCwtCvXz+kpaUhKipKaR3u0qUL1q9fj6FDh2LEiBFwdHTE/v37sWXLFgwbNkz6S7RXr16IjY2FkZER/Pz8cPbsWWzYsAHh4eHQ09NDZmYmrl27htq1a6s8XdGyZUusWLECwP9CWNOmTaWjyM9/Tu7u7vjll1+wYcMGNGjQAJcuXcLixYuV1oumTZti5cqVGDt2LDp37oy8vDzExMSgRo0aUmArq8Jl3rt3LwICAtCgQYNST1uaz7N69eoAgAMHDsDS0hINGzYsVdu9e/fGjh070Lt3b/Tt2xdWVlbYvXs3fvzxR+l2z0KdO3fGiBEjoFAo8OGHH0rDS7tNlmbdKVT4h1rh6aPSUFtYqF+/PkJDQ7FixQps2LABISEhmDRpElauXIlff/0Vtra2aNKkCRYsWIChQ4fi1KlT5X54k52dHUaNGoWpU6di+/bt+Oijj4qM06xZM6xcuRLz5s3DqFGjYGRkhMaNG2PGjBl45513yjS/uXPnIjIyErNnz0Z+fj5at26N7t27Y/v27dI4w4cPh62tLdauXYu4uDjUqFED7du3x5dfflniOeKBAwfC1NQUq1atwqpVq+Dl5YUxY8bgm2++kcZp2LAh1q1bh7lz5yI8PBxCCMjlcixcuBCtW7cu03K8yMrKChs2bEBERATGjh0LMzMz9OvXT+n6CJlMhqVLl2LevHmIjY1FWloaHB0dMWrUKKVTIz179oSpqSmWL1+OuLg4ODg4oH///ujfvz+AZ1+wY8aMwZo1a7Bnzx64urpiwYIF+Oyzzyq0DMCzI0nr1q3D7NmzMXPmTDx+/BhvvfUWvvrqK/Tt27dMbXXp0gUHDx6UdsTFPfq5Vq1acHV1xcGDByv8Rd2kSZOXbieJiYmIj49HVFSUdMgxNDQUP/30EyZNmgRvb+8ynVp7mY8//hhmZmaIiYlBXFwcTE1N4e3tjVmzZkmn1CIjIzFt2jTpKEDdunUxZcoU7Ny586WPxH1ew4YNsWTJEixcuBCjRo2CQqFAo0aNsGLFiiKn9AoZGBhg+fLliIiIwDfffAMDAwN07twZNWrUwM2bN6XxIiIiUKdOHWzZsgXLli2DnZ0devXqhSFDhpT4l+jkyZOl7TgjIwP+/v4YNGgQoqKipHHeffddLF++HAsWLMCIESNgaGgIV1dXrFy5ssIP5Klbty7Wrl2LyMhIjBw5EjY2NhgzZgwiIyOlcUxMTLBmzRrMnj0bP/zwAzIzM1G/fn1ERESgW7du0nj/+c9/YGNjg40bNyImJgaOjo74+uuvpW3uv//9L3r16oXvvvsOXbp0KbEmHx8fVK9eHba2ttK1Eq6urjA3N4e9vb3SadaxY8ciLy8PUVFRyM3NhaOjIwYPHoxr165h//79UCgUaNmyJWbNmoUVK1ZIFzX6+Phg9erV5V6PmzRpgubNm2P27NmIj49HdHR0qactzef5zjvvoGPHjli3bh0OHz5c5ChySezt7bFx40bMnj0b33zzDXJyclC3bt0inxXwLJRVr14dtWrVQr169ZTeK802WZp1p9ChQ4fg7u6udIruZWSirFd3vWbu3r2LM2fOoHXr1koXK40YMQJ37tzBtm3btFgdacuePXswfvx4HDp06KUXOZF6Xb16FTdu3EDbtm2VLoDs1q0bHBwcsGDBAi1WR6Tbnj59Cn9/f8yYMUPpLr+XUduRhapKT08PY8eORevWrdGtWzfo6+vj8OHD+O233/Ddd99puzzSkrZt22LlypXYsGED+vXrp+1yXitPnz7FF198gR49eqBNmzZQKBTYvXs3zp8/j9GjR2u7PCKdtnHjRrzzzjtlPjLNIwulcOzYMSxcuBAXL15Efn4+GjRogD59+hR5rgK9Xm7fvo2QkBBs376dPyb1iv36669Yvnw5rl+/DiEEXFxcMHjw4DKdgyV63aSlpeGjjz7CmjVrUKdOnTJNy7BAREREKqnth6SIiIioamJYICIiIpUYFoiIiEglhgUiIiJSibdOvkAIAYWioNgfsCn99PnQ1zcodxtVFftGs9i/msX+1Sxd6l89PZnWa9A1DAsvyM3NRUrKIxgZFf3Vv9JNn42kpNtwcKhd7jaqKvaNZrF/NYv9q1m61L/W1mbQ12dYeB5PQxAREZFKDAtERESkEsMCERERqcSwQERERCoxLBAREZFKvBuCiOg1V1BQAIUiX6s15OfnSf+XyTT7d6y+vgH09Pi3clkwLBARvaaEEHj0KA1ZWZnaLgVCCOjp6SMjI/WVPOPAxMQcFhbWfJ5CKTEsEBG9pgqDgrm5FYyMqmn1i7OgoAD5+XkwMDDU6F/9Qgjk5uYgMzMdAGBpaaOxeVUlDAsakJSUhAcPHsLQ0KhC7Vhb28DRsZaaqiIi+p+CAoUUFMzNLbRdDgoKCgAAhoZGGj9FYGRUDQCQmZmO6tWteEqiFBgW1Ozu3UR07doNOTnZFW7L2NgUR4+eZGAgIrVTKBQA/vfF+bopXG6FIh96ehX7w+51wLCgZmlpacjJyUb79stRs6ZLudtJTb2E3bv7IC0tlWGBiDTmdT1n/7oud3kxLGiItbUT7O29tF0GERFRhTEsEBFRmTx9+hQxMYtx4MB+PHyYDlvbmmje/F307TsQFhbav/6B1I9XdRARUZlMnz4FP/64AUIIeHr6IDc3F5s3x2HixHAIIbRdHmkAjywQEVGpPXmSiYMH98Pa2gZxcdthZGSEp0+fomfPbvjrrwQkJt5BrVq1tV0mqRnDAhERlZq+vgFkMhkyMh7il192oV2792Fqaoq5cxciIyMDVlbWEEJg9eoV2LFjKx4+fIi6deti0KDh8PNrCgDIzs7G0qULsX//b3j8+DGcnBpi4MBhcHZ+dlF4RMQ3+OWXXejbdwC2b98CCwtLrF69Ebdu/YPZsyNx4cJ5WFlZo1u3z9C9e4g2u+O1wdMQRERUasbGxggICIJCocDMmdPx/vut8Z//fIFLly7A1bURzM3NsXlzHJYtW4ycnGy4uXngxo3rGDv2K9y+fQsAMGFCODZt2gB9fQM4O7vi/Pm/MXLkUFy+fElpXqtWLUedOnXh6toIeXl5+Oqr4Th37gxcXd0gk8mwcGEUtm/frI1ueO3wyAIREZXJ2LFfw9zcHL/99gtyc3MQH38E8fFH8NNP2xEVtQjr1q2Cvr4+li6NhaNjLezYsRVHjx5GSsoDPHyYjuPHj6Ju3XqIiVkDY2NjbN68EVFRs7BmzUrMmDFXmk/79h9g3LhJAIBdu3YgOfk++vTpj7CwgcjKykLXrh2xeXMcPvqom7a64rXBIwtERFQm5ubmGDv2a+zYsQeTJn2L1q3bQl9fH2fPnsa+fXuQkvIAdnYO0jNiPvywC2bMmAtv78b473/PAwACAoJgbGwMAGjX7gMAwMWLF5Tm4+rqJv375s0bAICVK5fh3Xcbo00bfzx6lIFbt/5BVlaWxpf5dccjC0REVGrnzp1BXNw6uLq6oUePXmjbtj3atm2PmJgliI2NwdWrlwFA6Vcs8/PzIZPJoK+vDz29kh+G9OKDkszMzKR/F7bn5OQMOzs7pfHy8nJhYmJS4WWjkvHIAhERlZqZmTkOHvwD69evQUpKijT83r1/AQB2dvawta2JlJQHuHXrHwDAtm2b0aZNAOLi1uGdd5wAAIcO/YHs7GePxd+z52cAgIuLq9K8nv/Nhrp16wEAPD298N13s/H111NhY1MTzZv7w8LCUjMLSxIeWSAiolJr0OBttGwZhIMH/0BISDc4O7viwYNk/PPPTdSoUQNt23aAnp4e5s2bg8GDwyCXO+Hs2dOQyWTw82uGOnXqwsPDC2fPnkaPHl3xxhtv4ty5MzAyqoZevfqWON82bdpj2bLFiItbjwsXziM5ORn37ychOPjjV7j0ry8eWSAiojKZOHEqevfuBysra5w9exppaWnw9w/E/PnRsLa2QbdunyEsbCCMjIxw7txZ1KvXANOnz0K9evWhp6eH77+fiy5dPoZCkY+LF/+LRo3cERW1EG+//U6J8zQzM8fcuQvh6emNy5cvIycnB926fYoRI0a9wiV/fckEH7elJCcnBykpj2BkZFyu6U+dOoEOHd5Djx5/4s03G5e7jvv3T2PNmmbYt+8Q3N09y92OLsnNzUZS0m04ONQud/9Sydi/mlXV+jcvLxepqfdgY/MGDA21/6uLBQUFyMvLfSU/UQ2oXn5razPo6/Nv6eexN4iIiEglhgUiIiJSSafDQn5+Pn744QcEBQXBy8sLPXv2xJkzZ6T3L168iJCQEHh6eqJVq1ZYvXq19oolIiKqonQ6LCxevBibNm3CtGnTsH37dtSrVw/9+vVDcnIy0tPT0adPH9SuXRtbtmzB0KFDMWvWLGzZskXbZRMREVUpOn3r5L59+9CxY0e8++67AICxY8di06ZNOHPmDG7evAlDQ0NMnToVBgYGaNCgAW7duoXo6Gh07dpVy5UTERFVHTp9ZMHGxgZ//PEHEhMToVAoEBcXByMjIzRs2BAJCQnw8/ODgcH/8k7Tpk3xzz//KD0ohIiIiCpGp48sTJgwAV988QVat279/48J1cP8+fNRu3ZtJCUlQS6XK41f+AjQe/fuwdbWttzzzcvLLfe0+fl5AAAhFEqPOy0rhUIh1ZKbm13udnRJYb9WpH+pZOxfzapq/ZufnwchBAoKClBQUKDtclB4F39hTZpWUFAAIQTy8nIghPL8hDDV+PwrG50OC9euXUP16tWxcOFC2NvbY9OmTRg9ejTWrl2L7OxsGBkp3xtbrVo1AM+elVARqalJ5Z42IyMVAJCdnYXMzIxyt5OVlSnVkpRUo9zt6KKK9C+9HPtXs6pS/+rp6Ut/4OiKV1VPfn4eFAoFUlLuFXnP1tYCBgb6r6SOykJnw8K9e/fw1VdfITY2Fo0bP3u4kZubG65du4b58+fD2NgYubnKCb8wJJiaViwV2tg4lPshJffuPQAAGBubwNy8/M8rf/LEXKrFwaF2udvRJc8egpJUof6lkrF/Nauq9W9+fh4yMlJhYGCoE8sjhEB+fh4MDAyL/KCUpujr68Pa2g4GBoYvDNfZr0at0dkeOXv2LPLy8uDm5qY03MPDA4cOHcKbb76J5ORkpfcKX9vb21do3oaGRuV+QlvhSieT6VdohdPX169wLbqqKi6TLmH/alZV6V+ZTA8ymQx6enpFnpiYmHgHaWmpr7SegoIC5Ofnw87OHrVr19H4/PT0ni2/oWG1ImHpVYWVykRnw4KDgwMA4PLly3B3d5eGX7lyBXXr1oWHhwc2btwIhUIhfbEeO3YM9erVg42NjVZqJiKq7BIT7+Dd5o3xNDtLK/M3NTbGn0dPwdGxVpmmKygowMqVy/DTT9uRmfkYnp7eGDVqDN588y0NVfp60dmw4O7uDh8fH4wZMwaTJ0+Gg4MDtm/fjvj4eGzYsAGOjo6IiYnBhAkT0K9fP5w7dw6xsbGYMmWKtksnIqq00tJS8TQ7C8vf7wSnV/iHlxACl1IeoP+vu5GWllrmsBAbG4Nt2zZh/PhvULOmHRYvnodRo4ZjzZo4GBoavrwBUklnw4Kenh4WL16MqKgojBs3DhkZGZDL5YiNjYWHhwcAICYmBhEREQgODkbNmjURHh6O4OBgLVdORFT5OdnYwNPe4ZXNryJ3QeTl5WHjxnUYPHg4mjd/9lyeKVO+w0cftceBA7+jTZv26iz1taSzYQEALC0tMXnyZEyePLnY993d3REXF/eKqyIiIl1y9eplPH36BD4+vtKw6tWrQy5viLNnTzMsqIFOP5SJiIjoZR48KP7idlvbmkhOvq+NkqochgUiIqrUsrOfPbjuxbsajIyMkJNTNR6ipW0MC0REVKkVPpDvxadr5ubmwsSk8t/mqgsYFoiIqFKzs3t2+uHF3wVKSXkAW1s7bZRU5TAsEBFRpfb223KYmZnh9OkEadjjx49x5coleHp6abGyqkOn74YgIiJ6GSMjI3Tp8gkWL56PGjWs4ODwJhYt+gF2dvYIDGyt7fKqBIYFIiIq4nLqq33csxACVyrwiOl+/QZBoVAgMvJb5OTkwNPTC3PmLICBAb/m1IG9SEREEmtrG5gamyBs909amb+psTGsrcv+5Eh9fX0MGTICQ4aM0EBVxLBAREQSR8da+PNoglZ/SKqsj3omzWNYICIiJY6OtV75F3ZBQQHy8nJ14ueyqSjeDUFEREQqMSwQERGRSgwLREREpBLDAhEREanEsEBEREQqMSwQERGRSgwLREREpBKfs0BEREoSE+9o9aFMtWvXqVBba9asxPHj8ViwIFpN1RHDAhERSRIT76B5c19kZz/VyvyNjU1x9OjJcj8UauvWTVi2bDHc3T3VW9hrjmGBiIgkaWmpyM5+ivffXwkbm4avbL5CCKSkXMSvv4YhLS21zGEhJeUBvv9+Ok6fTkCtWrU1VOXri2GBiIiKsLFpCHt7r1c2PyEECgoKyj39pUsXYWhogNjYDYiNjcG9e/+qsTpiWCAiokrv3XcD8O67Adouo8ri3RBERESkEsMCERERqcSwQERERCoxLBAREZFKDAtERESkEu+GICKiIlJTL73S+QkhkJZ2+ZXOk0qPYYGIiCTW1jYwNjbF7t19tDJ/Y2NTWFvbVKiNCRO+UU8xJGFYICIiiaNjLRw9elKrvw1R3kc9k+YwLBARkRJHx1qv/Au7oKAAeXm5MDQ0eqXzpdLhBY5ERESkEsMCERERqcSwQERERCoxLBARvcaEENouQSte1+UuL4YFIqLXkL6+PgAgNzdHy5VoR+Fy6+vzOv/SYC8REb2G9PT0YWJijszMdACAkVE1yGQyrdXz7NbJvP+vTXN/xwohkJubg8zMdJiYmGt0XlUJwwIR0WvKwsIaAKTAoE1CCCgUCujr67+S0GJiYi4tP72czoeF7du3Izo6Gnfu3EHt2rUxbNgwdOjQAQCQmJiIadOm4eTJkzA1NUW3bt0wfPhw6fAaERGVTCaTwdLSBtWrW0GhyNdqLXl5OUhJuQdrazsYGlbT6Lz09Q14RKGMdDos7NixAxMmTMD48ePh7++Pn3/+GaNGjYKDgwMaNWqEsLAw1K1bFxs3bsTt27cxYcIE6OnpYcSIEdounYio0tDT04OennYfhiREAQDAwMCQD2bSQTobFoQQ+OGHH9CrVy/07NkTADB48GAkJCTgxIkTuHv3Lv7991/8+OOPsLS0hFwuR2pqKr7//nsMGjQIRkZc2YiIiNRBZ4/D3Lx5E3fv3kWnTp2Uhi9fvhwDBw5EQkICXF1dYWlpKb3XtGlTZGZm4uLFi6+6XCIioipLZ48s3Lx5EwDw9OlThIWF4cKFC3B0dMTgwYPRqlUrJCUlwcHBQWkaOzs7AMC9e/fg4eFR7nnn5eWWe9rCq3mFUFToHKBCoZBqyc3NLnc7uqSwXyvSv1Qy9q9msX81S5f6VwhTbZegc3Q2LGRmZgIAxowZg2HDhmH06NHYs2cPhgwZgpUrVyI7OxsWFhZK01Sr9uyimJycit03nJqaVO5pMzKe/VJbdnYWMjMzyt1OVlamVEtSUo1yt6OLKtK/9HLsX81i/2qWLvSvra0FDAx4ofzzdDYsGBoaAgDCwsIQHBwMAHB2dsaFCxewcuVKGBsbIzdXOYEWhgRT04qlQhsbh3JfYHPv3gMAgLGxCczNLV8ydsmePDGXanFwqF3udnRJXl4uUlOTKtS/VDL2r2axfzVLl/qXD2oqSmd7xN7eHgAgl8uVhr/99ts4cOAA/Pz8cOXKFaX3kpOTlaYtL0NDIxgZGZdrWgODZyFHJtOv0ApXePtnRWrRVVVxmXQJ+1ez2L+apQv9q82HU+kqnb3A0dXVFWZmZjh79qzS8CtXrqB27drw9fXFhQsXpNMVAHDs2DGYmZmhYcOGr7pcIiKiKktnw4KxsTH69euHhQsXYteuXbh9+zYWL16MI0eOoE+fPnjvvfdQs2ZNfPnll7h06RL27duHOXPmoG/fvrxtkoiISI109jQEAAwZMgQmJiaYO3cu7t+/jwYNGmD+/Plo0qQJACAmJgZTpkzBJ598AktLS/To0QNDhgzRctVERERVi06HBQDo06cP+vTpU+x7derUwYoVK15xRURERK8XnT0NQURERLqBYYGIiIhUYlggIiIilRgWiIiISCWGBSIiIlLplYeFpCTtP/ebiIiISk/tYcHZ2Rnnzp0r9r2EhAR06NBB3bMkIiIiDVLLcxZWrFiBp0+fAgCEENi0aRMOHTpUZLzTp0/z6YpERESVjFrCQk5ODhYsWADg2Q9wbNq0qcg4enp6qF69OgYPHqyOWRIREdEropawMHjwYCkENGzYED/++CPc3d3V0TQRERFpmdof93zp0iV1N0lERERapJHfhjhy5Aj++OMPZGVloaCgQOk9mUyG6dOna2K2REREpAFqDwsrVqzA999/j2rVqsHa2hoymUzp/RdfExERkW5Te1hYu3YtOnXqhIiICN75QEREVAWo/TkLKSkp6NatG4MCERFRFaH2sODi4oKrV6+qu1kiIiLSErWfhhg/fjy+/PJLmJqawsPDAyYmJkXGefPNN9U9WyIiItIQtYeF7t27o6CgAOPHjy/xYsaLFy+qe7ZERESkIWoPC9OmTeMdD0RERFWI2sNCly5d1N0kERERaZHaw8LJkydfOo6vr6+6Z0tEREQaovawEBoaCplMBiGENOzF0xK8ZoGIiKjyUHtYWL16dZFhT58+RUJCAnbs2IH58+ere5ZERESkQWoPC35+fsUODwwMhKmpKRYvXoylS5eqe7ZERESkIWp/KJMqjRs3xokTJ17lLImIiKiCXmlY2L9/P8zMzF7lLImIiKiC1H4aolevXkWGFRQUICkpCXfv3kX//v3VPUsiIiLSILWHhefvgiikp6cHuVyOgQMHomvXruqeJREREWmQ2sPCmjVr1N0kERERaZHaw0KhQ4cO4cSJE3j06BGsra3h4+MDf39/Tc2OiIiINETtYSE3NxdDhgzBn3/+CX19fVhZWSE9PR1Lly5F06ZNsXTpUhgZGal7tkRERKQhar8bYv78+Th16hS+//57nDt3Dn/++SfOnj2L7777DmfOnMHixYvVPUsiIiLSILWHhV27dmHYsGHo3Lkz9PX1AQAGBgb46KOPMGzYMPz000/qniURERFpkNrDQlpaGlxcXIp9z8XFBffv31f3LImIiEiD1B4WateujVOnThX73smTJ/HGG2+oe5ZERESkQWq/wPGzzz5DZGQkjI2N8cEHH8DW1hYpKSnYtWsXli1bhmHDhql7lkRERKRBag8L3bt3x4ULFzBr1izMnj1bGi6EQHBwMAYMGKDuWRIREZEGaeTWyYiICPTt2xcnTpxARkYGZDIZ3nvvPTRo0KDc7d68eRNdunTB119/jS5dugAALl68iIiICJw/fx7W1tbo3bt3sY+bJiIiovJT2zULly9fRteuXbFy5UoAQIMGDdC9e3f06NEDP/zwA0aNGoWbN2+Wq+28vDyMHj0aT58+lYalp6ejT58+qF27NrZs2YKhQ4di1qxZ2LJli1qWh4iIiJ5RS1hITExEr169kJKSgnr16im9Z2hoiPDwcDx8+BA9evQo190Q8+fPh7m5udKwH3/8EYaGhpg6dSoaNGiArl27onfv3oiOjq7QshAREZEytYSF6Oho1KhRA9u2bUP79u2V3jMxMUHv3r2xefNmVKtWDUuXLi1T2ydPnkRcXBwiIyOVhickJMDPzw8GBv87k9K0aVP8888/SElJKf/CEBERkRK1XLMQHx+PAQMGwNrausRxatasib59+2LdunWlbvfRo0cIDw/HxIkTi9xymZSUBLlcrjTMzs4OAHDv3j3Y2tqWYQmU5eXllnva/Pw8AIAQCigU+eVuR6FQSLXk5maXux1dUtivFelfKhn7V7PYv5qlS/0rhKm2S9A5agkLycnJqFu37kvHk8vlSEpKKnW733zzDby8vNCpU6ci72VnZxf5jYlq1aoBAHJycko9j+Kkppa+xhdlZKQCALKzs5CZmVHudrKyMqVakpJqlLsdXVSR/qWXY/9qFvtXs3Shf21tLWBgoK/tMnSKWsKCtbU1kpOTXzpeeno6LC0tS9Xm9u3bkZCQUOLjoY2NjZGbq5xAC0OCqWnFUqGNjQMMDcv3Y1f37j34//pMYG5eumUtzpMn5lItDg61y92OLsnLy0VqalKF+pdKxv7VLPavZulS/+rra+wHmSsttfSIr68vtm7dig8++EDleNu3by/xUdAv2rJlC1JTUxEYGKg0fPLkydi9ezccHByKBJTC1/b29qUvvhiGhkYwMjIu17QGBoYAAJlMv0IrXOHvalSkFl1VFZdJl7B/NYv9q1m60L8ymUyr89dFagkLoaGh6N69OyIjIzFy5EjpdECh3NxcREVF4dChQ6W+W2HWrFnIzlY+V9+2bVuMGDECnTt3xo4dO7Bx40YoFArpi/XYsWOoV68ebGxs1LFYREREBDWFBTc3N4wbNw7Tp0/Hjh070KxZMzg6OkKhUODff//F8ePHkZ6eji+++AL+/v6larOkowM2Njawt7dH165dERMTgwkTJqBfv344d+4cYmNjMWXKFHUsEhEREf0/tZ2Y6dmzJxo2bIjly5fj999/l64fMDMzw7vvvou+ffvCw8NDXbODjY0NYmJiEBERgeDgYNSsWRPh4eEIDg5W2zyIiIhIzY979vHxgY+PD4BnP1VtYGAACwsLtbV/+fJlpdfu7u6Ii4tTW/tERERUlMYu+VT1zAUiIiKqPNT22xBERERUNTEsEBERkUoMC0RERKQSwwIRERGpxLBAREREKjEsEBERkUoMC0RERKQSwwIRERGpxLBAREREKjEsEBERkUoMC0RERKQSwwIRERGpxLBAREREKjEsEBERkUoMC0RERKQSwwIRERGpxLBAREREKjEsEBERkUoMC0RERKQSwwIRERGpxLBAREREKjEsEBERkUoMC0RERKQSwwIRERGpxLBAREREKjEsEBERkUoMC0RERKQSwwIRERGpxLBAREREKjEsEBERkUoMC0RERKQSwwIRERGpxLBAREREKjEsEBERkUoMC0RERKQSwwIRERGppNNh4eHDh5g0aRICAgLg7e2N7t27IyEhQXo/Pj4eXbp0gYeHB9q3b4+ff/5Zi9USERFVTTodFkaNGoXTp09jzpw52LJlC5ydnREWFoYbN27g+vXrGDhwIPz9/bF161Z8/PHHCA8PR3x8vLbLJiIiqlIMtF1ASW7duoUjR45g/fr18PHxAQB8/fXXOHz4MH766SekpqbCyckJI0eOBAA0aNAAFy5cQExMDJo1a6bN0omIiKoUnT2yYGVlhejoaLi5uUnDZDIZZDIZHj16hISEhCKhoGnTpjh16hSEEK+6XCIioipLZ8OChYUFWrZsCSMjI2nYnj17cOvWLfj7+yMpKQkODg5K09jZ2SErKwvp6emvulwiIqIqS2dPQ7zor7/+wrhx49C2bVsEBgYiOztbKUgAkF7n5uZWaF55eeWfPj8/DwAghAIKRX6521EoFFItubnZ5W5HlxT2a0X6l0rG/tUs9q9m6VL/CmGq7RJ0TqUIC/v27cPo0aPh7e2NWbNmAQCqVatWJBQUvjYxManQ/FJTk8o9bUZGKgAgOzsLmZkZ5W4nKytTqiUpqUa529FFFelfejn2r2axfzVLF/rX1tYCBgb62i5Dp+h8WFi7di0iIiLQvn17zJgxQzp68MYbbyA5OVlp3OTkZJiamqJ69eoVmqeNjQMMDY1ePmIx7t17AAAwNjaBublluWt48sRcqsXBoXa529EleXm5SE1NqlD/UsnYv5rF/tUsXepffX2d/2p85XS6R9avX49p06YhNDQUEyZMgEwmk95r3LgxTpw4oTT+sWPH4O3tDT29il2KYWhoBCMj43JNa2BgCACQyfQrtMLp6+tXuBZdVRWXSZewfzWL/atZutC/z3/X0DM6GxZu3ryJ6dOno02bNhg4cCBSUlKk94yNjREaGorg4GDMmjULwcHBOHjwIH799VfExMRosWoiIqKqR2fDwp49e5CXl4e9e/di7969Su8FBwcjMjISixYtwsyZM7Fq1So4Ojpi5syZfMYCERGRmulsWBg0aBAGDRqkcpyAgAAEBAS8ooqIiIheTzr7nAUiIiLSDQwLREREpBLDAhEREanEsEBEREQqMSwQERGRSgwLREREpBLDAhEREanEsEBEREQqMSwQERGRSgwLREREpBLDAhEREanEsEBEREQqMSwQERGRSgwLREREpBLDAhEREanEsEBEREQqMSwQERGRSgwLREREpBLDAhEREanEsEBEREQqMSwQERGRSgwLREREpBLDAhEREanEsEBEREQqMSwQERGRSgwLREREpBLDAhEREalkoO0CSLWrVy9XuA1raxs4OtZSQzVERPQ6YljQUU+eJAGQYfDg/hVuy9jYFEePnmRgICKicmFY0FHZ2RkABFq0iEL9+k3K3U5q6iXs3t0HaWmpDAtERFQuDAs6ztLybdjbe2m7DCIieo3xAkciIiJSiWGBiIiIVGJYICIiIpUYFoiIiEglXuCoIWlpl6Gvr1/u6TMy/lFfMURERBXAsKBmycn3IQPw669hFW5LBiArK7nC7RAREVUEw4KaPXr0CALACMcAyK3eLnc7/00+g8X3/0Ju7iP1FUdERFQOlT4sFBQUYMGCBdi0aRMeP34MX19fTJo0CbVqafcBRI7VLPGO+Rvlnj49/boaqyEiIiq/Sn+B46JFi7B+/XpMmzYNGzduREFBAfr164fc3Fxtl0ZERFQlVOojC7m5uVixYgVGjx6NwMBAAMDcuXPh7++P3377DR07dtRugTqkoj9IxR+jIiJNS0pKwoMHD2FoaFShdri/Ur9KHRYuXbqEJ0+eoFmzZtIwCwsLuLi44OTJkwwLUN8PUvHHqIhIk+7eTUTXrt2Qk5Nd4ba4v1I/mRBCaLuI8vrtt98wfPhwnD17FsbGxtLwL774AtnZ2Vi6dGmZ2xRCID9fAZlMVq6anjzJRGpqKiz0jWAgK38WyyvIw+OCPBgamsPAwKTc7SgU2cjNfQwDAzPo65evHiEUyM3NhKVlDRgYVCRfChQUFEBPTw/P7vUg9WL/ahb7V5Py8/OQkZEBQ0Nz6OmV/7bzwv2Vg8MbMDIq3xEKfX29cn8HVFWV+shCVlYWABRZIapVq4aMjIxytSmTyWBoWP5usbS0hKWlZbmnf15NtbRSXU0t2amhDSKiktnY2KipJe6v1K1SX+BYeDThxYsZc3JyYGJS/r/GiYiI6H8qdVh4441ntyYmJys/uCg5ORn29vbaKImIiKjKqdRhoWHDhjA3N8fx48elYY8ePcKFCxfg6+urxcqIiIiqjkp9zYKRkRFCQkIwa9YsWFtb46233sLMmTPh4OCAtm3bars8IiKiKqFShwUAGDFiBPLz8zFx4kRkZ2fD19cXy5cvh6GhobZLIyIiqhIq9a2TREREpHmV+poFIiIi0jyGBSIiIlKJYYGIiIhUYlggIiIilRgWiIiISCWGBSIiIlKJYYGIiIhUYlgAUFBQgHnz5sHf3x+enp7o378/7ty5U6E2ly5ditDQUDVVWLndv38fTk5ORf7bunWrtkur9Ipbzy5evIiQkBB4enqiVatWWL16tZaqq/yK69+JEycWWZdbtWqlpQorn4cPH2LSpEkICAiAt7c3unfvjoSEBOn9+Ph4dOnSBR4eHmjfvj1+/vlnLVZLhSr9ExzVYdGiRVi/fj0iIyPh4OCAmTNnol+/fvjpp5/K9Xvo69atQ1RUFBo3bqyBaiufS5cuoVq1ati3b5/Sb8RXr15di1VVfsWtZ+np6ejTpw9atWqFKVOm4MyZM5gyZQrMzMzQtWtXLVZb+ZS0HV++fBmDBg1CSEiINExfX/9Vl1dpjRo1Cg8ePMCcOXNgY2ODNWvWICwsDNu2bYMQAgMHDkSfPn0wc+ZMHDhwAOHh4bC2tkazZs20Xfpr7bUPC7m5uVixYgVGjx6NwMBAAMDcuXPh7++P3377DR07dix1W/fv38fkyZNx/Phx1K1bVzMFV0JXrlxB3bp1YWfH35hXB1Xr2Y8//ghDQ0NMnToVBgYGaNCgAW7duoXo6GiGhVJS1b9CCFy7dg0DBgxAzZo1tVNgJXbr1i0cOXIE69evh4+PDwDg66+/xuHDh/HTTz8hNTUVTk5OGDlyJACgQYMGuHDhAmJiYhgWtOy1Pw1x6dIlPHnyRGlFtLCwgIuLC06ePFmmtv773//C0NAQO3fuhIeHh7pLrbQuX76MBg0aaLuMKkPVepaQkAA/Pz8YGPzv74CmTZvin3/+QUpKyqsutVJS1b+3b9/G06dPUb9+fS1VV7lZWVkhOjoabm5u0jCZTAaZTIZHjx4hISGhSCho2rQpTp06Bf4ygXa99kcWkpKSAABvvPGG0nA7OzvpvdJq1aoVz10W48qVK7CyskLPnj1x8+ZN1KlTB4MHD0ZAQIC2S6uUVK1nSUlJkMvlSsMKj+jcu3cPtra2Gq+vslPVv1euXAEArFmzBocOHYKenh4CAgIwcuRInlYrBQsLC7Rs2VJp2J49e3Dr1i2MHz8e27Ztg4ODg9L7dnZ2yMrKQnp6OqytrV9lufSc1/7IQlZWFgAUuTahWrVqyMnJ0UZJVUp+fj5u3LiBjIwMDB8+HNHR0fD09MSAAQMQHx+v7fKqnOzs7GLXZQBcn9XgypUr0NPTg52dHZYsWYKxY8fizz//xJAhQ1BQUKDt8iqdv/76C+PGjUPbtm0RGBhY7Ppb+Do3N1cbJdL/e+2PLBgbGwN4tiIW/ht4tmM1MTHRVllVhoGBAY4fPw59fX2pfxs1aoSrV69i+fLlPA+pZsbGxkV2qoUhwdTUVBslVSmDBw9Gjx49YGVlBQCQy+WoWbMmPvnkE/z99988/VgG+/btw+jRo+Ht7Y1Zs2YBeBZsX1x/C19zf6xdr/2RhcLTD8nJyUrDk5OTYW9vr42SqhwzMzOlIAYA77zzDu7fv6+liqouBweHYtdlAFyf1UBPT08KCoXeeecdACjzacvX2dq1azF8+HAEBQVhyZIl0tGvN954o9j119TUlKd5tOy1DwsNGzaEubk5jh8/Lg179OgRLly4AF9fXy1WVjVcvXoV3t7eSv0LAOfPn8fbb7+tpaqqLl9fX5w6dQoKhUIaduzYMdSrVw82NjZarKxqCA8PR+/evZWG/f333wDA9bmU1q9fj2nTpqFnz56YM2eO0mmHxo0b48SJE0rjHzt2DN7e3tDTe+2/rrTqte99IyMjhISEYNasWfj9999x6dIljBw5Eg4ODmjbtq22y6v0GjRogPr162Pq1KlISEjA9evX8d133+HMmTMYPHiwtsurcrp27YrMzExMmDAB165dw9atWxEbG4uBAwdqu7QqoV27doiPj8eCBQtw+/ZtHDx4EOPHj0fHjh15x08p3Lx5E9OnT0ebNm0wcOBApKSk4MGDB3jw4AEeP36M0NBQnDt3DrNmzcL169exYsUK/Prrr+jXr5+2S3/tvfbXLADAiBEjkJ+fj4kTJyI7Oxu+vr5Yvnw5DA0NtV1apaenp4clS5Zg9uzZ+PLLL/Ho0SO4uLhg5cqVRa7ap4qzsbFBTEwMIiIiEBwcjJo1ayI8PBzBwcHaLq1KaN26NaKiohAdHY1ly5ahevXq6NSpE7788kttl1Yp7NmzB3l5edi7dy/27t2r9F5wcDAiIyOxaNEizJw5E6tWrYKjoyNmzpzJa5t0gEzw5lUiIiJS4bU/DUFERESqMSwQERGRSgwLREREpBLDAhEREanEsEBEREQqMSwQERGRSgwLREREpBIfykRUhYSGhhZ5XK5MJoOpqSnq1q2Lzz//HB9++KFa5zl//nwsWLAAly9fVmu7RKQ7GBaIqhgXFxdMnjxZeq1QKJCUlITY2FiEh4ejRo0aaNmypRYrJKLKhmGBqIoxNzeHp6dnkeEBAQFo1qwZtm7dyrBARGXCsED0mqhWrRqMjIwgk8kAAGlpaZg/fz4OHDiABw8ewNTUFL6+vhg3bhwcHR0BPDutUbt2bdSpUwfr169HamoqXF1dMX78eLi7uxc7n3///Rc9evSAtbU1YmNjYWFh8cqWkYg0g2GBqIoRQiA/P196rVAocPfuXSxcuBBPnjzBhx9+CCEEBg4ciIyMDIwePRq2tra4fPkyoqKiMHnyZCxfvlyafs+ePWjQoAEmTpwIIQRmzJiB4cOHY//+/dDX11ea94MHD9C7d2/UqFEDK1euZFAgqiIYFoiqmJMnT8LV1VVpmEwmg1wuxw8//ICgoCDcv38fJiYmGDNmDBo3bgwAaNKkCW7fvo24uDilafPz87F8+XKYm5sDAJ48eYIxY8bg4sWLaNSokTReeno6+vTpA2NjY6xcuRKWlpYaXlIielUYFoiqGFdXV0yZMgUAkJycjKioKOTl5SEqKgr169cHANjb22P16tUQQiAxMRG3bt3CjRs38NdffyE3N1epvbffflsKCoXTAkBWVpbSeP369cPVq1exatUqWFlZaXIRiegVY1ggqmLMzMzg5uYmvfbw8EDnzp3Rt29fbN26FdbW1gCAnTt3Ys6cObh37x5q1KgBZ2dnGBsbF2nPxMRE6bWe3rPHsxQUFCgNz8rKgqOjI2bPno24uDhpPCKq/Lg1E1Vxtra2mDRpEu7du4eIiAgAQEJCAsaMGYO2bdvi0KFDOH78OGJjY4u9i6K0Vq1ahcmTJ+PcuXNYvXq1mqonIl3AsED0Gmjfvj38/f2xa9cunDhxAqdPn0ZBQQGGDx8unVZQKBQ4evQogKJHDUqjZs2aCAgIQIcOHfDDDz8gMTFRrctARNrDsED0mhg/fjwMDQ3x7bffShcmTp06FceOHcOePXvQp08fXLp0CQDw9OnTCs1HT09P6cFQRFS5MSwQvSbq16+P0NBQXL58GdevX8ekSZNw+vRp9O/fH5GRkXjzzTexYMECAMCpU6fKPR87OzuMGjUKf/75J7Zv366m6olIm2RCCKHtIoiIiEh38cgCERERqcSwQERERCoxLBAREZFKDAtERESkEsMCERERqcSwQERERCoxLBAREZFKDAtERESkEsMCERERqcSwQERERCoxLBAREZFKDAtERESk0v8BMKDzsxO/2kgAAAAASUVORK5CYII=",
             "text/plain": [
               "<Figure size 500x300 with 1 Axes>"
             ]
@@ -737,17 +747,27 @@
         "\n",
         "sns.set_theme(style=\"darkgrid\", rc={\"grid.color\": \".8\"})\n",
         "\n",
-        "# create offsets for better vis\n",
-        "results[\"rank_shifted_left\"] = results[\"rank\"] - 0.1\n",
-        "results[\"rank_shifted_right\"] = results[\"rank\"] + 0.1\n",
+        "# Create a custom palette for score coloring\n",
+        "custom_palette = {0: \"red\", 1: \"blue\"}\n",
         "\n",
         "f, ax = plt.subplots(figsize=(5, 3))\n",
-        "sns.histplot(data=results, x=\"rank_shifted_left\", color=\"skyblue\", label=\"Correct answer\", binwidth=1)\n",
+        "sns.histplot(\n",
+        "    data=results,\n",
+        "    x=\"rank\",\n",
+        "    hue=\"score\",\n",
+        "    palette=custom_palette,\n",
+        "    edgecolor=\"black\",\n",
+        "    binwidth=1\n",
+        ")\n",
         "\n",
         "ax.set_xticks([1, 5, 0, 10, 15, 20])\n",
         "ax.set_title(\"Rank of golden document (max means golden doc. wasn't retrieved)\")\n",
         "ax.set_xlabel(\"Rank\")\n",
-        "ax.legend();\n"
+        "\n",
+        "legend = ax.get_legend()\n",
+        "legend.set_title(\"Score\")\n",
+        "legend.get_title().set_fontsize('small')\n",
+        "legend.get_title().set_fontweight('bold')\n"
       ]
     },
     {
@@ -756,7 +776,7 @@
         "id": "PZeTt7ijVKxo"
       },
       "source": [
-        "We see that retrieval works well overall: for 80% of questions, the golden document is within the top 5 documents. However, we also notice that approx. half the false answers come from instances where the golden document wasn't retrieved (`rank = top_k = 20`). This should be improved, e.g. by adding metadata to the documents such as their section headings, or altering the chunking strategy.\n",
+        "We see that retrieval works well overall: for about over 95% of questions, the golden document is consistently within the top 5 documents. However, we also notice that approx. half the false answers come from instances where the golden document wasn't retrieved (`rank = top_k = 20`). This should be improved, e.g. by adding metadata to the documents such as their section headings, or altering the chunking strategy.\n",
         "\n",
         "There is also a non-negligible instance of false answers where the top document was retrieved. On closer inspection, many of these are due to the model phrasing its answers more verbosely than the (very laconic) golden documents. This highlights the importance of checking eval results before jumping to conclusions about model performance."
       ]

--- a/notebooks/guides/Creating_a_QA_bot_from_technical_documentation.ipynb
+++ b/notebooks/guides/Creating_a_QA_bot_from_technical_documentation.ipynb
@@ -42,20 +42,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "id": "kJ_9dyJxG0zA"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "/Users/neel/Library/Caches/pypoetry/virtualenvs/notebooks-WcB_wkWy-py3.11/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-            "  from .autonotebook import tqdm as notebook_tqdm\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "import os\n",
         "import random\n",
@@ -87,8 +78,8 @@
       "outputs": [],
       "source": [
         "# Set up Cohere client\n",
-        "# TODO: delete before push\n",
-        "api_key = os.getenv(\"COHERE_API_KEY\") # <your API key>\n",
+        "api_key = \"\" # <your API key>\n",
+        "# Setup Cohere client with experiment logging disabled (for JSON structured output)\n",
         "co = cohere.Client(api_key=api_key, log_warning_experimental_features=False)\n",
         "\n",
         "stub_len = len(\"https://github.com/siagholami/aws-documentation/tree/main/documents/\")"
@@ -167,10 +158,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# -- to fix SSL error -- \n",
-        "import ssl\n",
-        "ssl._create_default_https_context = ssl._create_unverified_context\n",
-        "\n",
         "# Load data from github\n",
         "url = \"https://github.com/siagholami/aws-documentation/blob/main/QA_true.csv?raw=true\"\n",
         "qa_pairs = pd.read_csv(url)\n",


### PR DESCRIPTION
This PR covers the following changes:

- Added native JSON Structured formatting to the generated response
- Added a boolean flag to control the sampling of the full or partial dataset. For partial sampling, added a if-else to add the eval samples in the vectorstore to ensure parity between ground-truth and eval datasets.
- Fixed issues with eval data persistence
- Fixed histogram plot at the end

End-to-end notebook run successfully complete before final push.