### PR TITLE
feat: add create_sql_agent to cookbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,182 @@
+.vs/
+.vscode/
+.idea/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Google GitHub Actions credentials files created by:
+# https://github.com/google-github-actions/auth
+#
+# That action recommends adding this gitignore to prevent accidentally committing keys.
+gha-creds-*.json
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+docs/docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+notebooks/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv*
+venv*
+env/
+ENV/
+env.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.mypy_cache_test/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# macOS display setting files
+.DS_Store
+
+# Wandb directory
+wandb/
+
+# asdf tool versions
+.tool-versions
+/.ruff_cache/
+
+*.pkl
+*.bin
+
+# integration test artifacts
+data_map*
+\[('_type', 'fake'), ('stop', None)]
+
+# Replit files
+*replit*
+
+node_modules
+docs/.yarn/
+docs/node_modules/
+docs/.docusaurus/
+docs/.cache-loader/
+docs/_dist
+docs/api_reference/*api_reference.rst
+docs/api_reference/_build
+docs/api_reference/*/
+!docs/api_reference/_static/
+!docs/api_reference/templates/
+!docs/api_reference/themes/
+docs/docs/build
+docs/docs/node_modules
+docs/docs/yarn.lock
+_dist
+docs/docs/templates
+
+prof
+virtualenv/

--- a/notebooks/agents/sql_agent/sql_agent.ipynb
+++ b/notebooks/agents/sql_agent/sql_agent.ipynb
@@ -19,13 +19,264 @@
     "Enterprise customers often store and handle information in relational databases but querying such databases effectively requires bespoke knowledge of the underlying database structure as well as strong SQL coding skills. One way to address these challenges is to build an LLM agent capable of generating and executing SQL queries based on natural language. For example If a user asks: ``what are the top 4 rows in table X``, the agent should be able to generate ``SELECT * FROM X LIMIT 4``, execute this query and return the output to the user. \n",
     "\n",
     "## Objective\n",
-    "In this notebook we explore how to setup a [Cohere ReAct Agent](https://github.com/langchain-ai/langchain-cohere/blob/main/libs/cohere/langchain_cohere/cohere_agent.py) to answer questions over SQL Databases. We show how this can be done seamlessly with langchain's existing SQLDBToolkit.\n",
+    "In this notebook we explore how to setup a sql agent using langchain and Cohere models. We explore two ways to achieve this, one using the [create_sql_agent](https://api.python.langchain.com/en/latest/sql_agent/langchain_cohere.sql_agent.agent.create_sql_agent.html) abstraction from langchain-cohere, and another using the [Cohere ReAct Agent](https://github.com/langchain-ai/langchain-cohere/blob/main/libs/cohere/langchain_cohere/cohere_agent.py) to answer questions over SQL Databases. We show how this can be done seamlessly with langchain's existing SQLDBToolkit.\n",
     "\n",
     "## Table of Contents\n",
     "\n",
-    "- [Toolkit Setup](#sec_step0)\n",
-    "- [SQL Agent](#sec_step1)\n",
-    "- [SQL Agent with context](#sec_step2)"
+    "- [SQL Agent with create_sql_agent](#sec_step0)\n",
+    "- [SQL Agent using Cohere ReAct Agent](#sec_step1)\n",
+    "    - [Toolkit Setup](#sec_step2)\n",
+    "    - [SQL Agent](#sec_step3)\n",
+    "    - [SQL Agent with context](#sec_step4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63944c4c",
+   "metadata": {},
+   "source": [
+    "<a id=\"sec_step0\"></a>\n",
+    "# SQL Agent with create_sql_agent\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "87082b5e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_cohere import ChatCohere, create_sql_agent\n",
+    "from langchain_community.utilities.sql_database import SQLDatabase\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "809a7264",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "####################################################################################################\n",
+    "#\n",
+    "# Uncomment if you need to install the following packages\n",
+    "#\n",
+    "####################################################################################################\n",
+    "\n",
+    "#!pip install --quiet langchain langchain_cohere langchain_experimental --upgrade"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "e345b433",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load the cohere api key\n",
+    "os.environ[\"COHERE_API_KEY\"] = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "24e44db7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DB_NAME='Chinook.db'\n",
+    "MODEL=\"command-r-plus\"\n",
+    "\n",
+    "llm = ChatCohere(model=MODEL, temperature=0.1,verbose=True, cohere_api_key=\"b8CMN0hK0ZYJaXUe9B6FqHdXxKNsT6SVSDq9Cuad\")\n",
+    "db = SQLDatabase.from_uri(f\"sqlite:///{DB_NAME}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "c2633201",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent_executor = create_sql_agent(llm, db=db, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e8799f1",
+   "metadata": {},
+   "source": [
+    "The create_sql_agent abstraction comes with access to the SQLDBTookit, and presents itself as an easy-to-use low-code solution to create an agent to answer questions over a db knowledge source. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "48424219",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new Cohere SQL Agent Executor chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3m\n",
+      "Invoking: `sql_db_list_tables` with `{'tool_input': ''}`\n",
+      "responded: I will use the sql_db_list_tables tool to find out what tables are available in the database.\n",
+      "\n",
+      "\u001b[0m\u001b[38;5;200m\u001b[1;3mAlbum, Artist, Customer, Employee, Genre, Invoice, InvoiceLine, MediaType, Playlist, PlaylistTrack, Track\u001b[0m\u001b[32;1m\u001b[1;3mThe following tables are available:\n",
+      "- Album\n",
+      "- Artist\n",
+      "- Customer\n",
+      "- Employee\n",
+      "- Genre\n",
+      "- Invoice\n",
+      "- InvoiceLine\n",
+      "- MediaType\n",
+      "- Playlist\n",
+      "- PlaylistTrack\n",
+      "- Track\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'input': 'what tables are available?',\n",
+       " 'output': 'The following tables are available:\\n- Album\\n- Artist\\n- Customer\\n- Employee\\n- Genre\\n- Invoice\\n- InvoiceLine\\n- MediaType\\n- Playlist\\n- PlaylistTrack\\n- Track'}"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "agent_executor.invoke({\n",
+    "   \"input\": 'what tables are available?',\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04647284",
+   "metadata": {},
+   "source": [
+    "The agent is able to invoke the correct tool from the toolkit in order to find out the tables available in the db."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "e960bacb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new Cohere SQL Agent Executor chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3m\n",
+      "Invoking: `sql_db_list_tables` with `{}`\n",
+      "responded: I will first list the tables in the database, then I will query the schema of the most relevant tables. After that, I will write and execute a SQL query to answer the user's question.\n",
+      "\n",
+      "\u001b[0m\u001b[38;5;200m\u001b[1;3mAlbum, Artist, Customer, Employee, Genre, Invoice, InvoiceLine, MediaType, Playlist, PlaylistTrack, Track\u001b[0m\u001b[32;1m\u001b[1;3m\n",
+      "Invoking: `sql_db_schema` with `{'table_names': 'Customer, Invoice'}`\n",
+      "responded: The tables in the database are: Album, Artist, Customer, Employee, Genre, Invoice, InvoiceLine, MediaType, Playlist, PlaylistTrack, Track.\n",
+      "\n",
+      "The most relevant tables for the user's question are Customer and Invoice. I will now query the schema of these tables.\n",
+      "\n",
+      "\u001b[0m\u001b[33;1m\u001b[1;3m\n",
+      "CREATE TABLE \"Customer\" (\n",
+      "\t\"CustomerId\" INTEGER NOT NULL, \n",
+      "\t\"FirstName\" NVARCHAR(40) NOT NULL, \n",
+      "\t\"LastName\" NVARCHAR(20) NOT NULL, \n",
+      "\t\"Company\" NVARCHAR(80), \n",
+      "\t\"Address\" NVARCHAR(70), \n",
+      "\t\"City\" NVARCHAR(40), \n",
+      "\t\"State\" NVARCHAR(40), \n",
+      "\t\"Country\" NVARCHAR(40), \n",
+      "\t\"PostalCode\" NVARCHAR(10), \n",
+      "\t\"Phone\" NVARCHAR(24), \n",
+      "\t\"Fax\" NVARCHAR(24), \n",
+      "\t\"Email\" NVARCHAR(60) NOT NULL, \n",
+      "\t\"SupportRepId\" INTEGER, \n",
+      "\tPRIMARY KEY (\"CustomerId\"), \n",
+      "\tFOREIGN KEY(\"SupportRepId\") REFERENCES \"Employee\" (\"EmployeeId\")\n",
+      ")\n",
+      "\n",
+      "/*\n",
+      "3 rows from Customer table:\n",
+      "CustomerId\tFirstName\tLastName\tCompany\tAddress\tCity\tState\tCountry\tPostalCode\tPhone\tFax\tEmail\tSupportRepId\n",
+      "1\tLuís\tGonçalves\tEmbraer - Empresa Brasileira de Aeronáutica S.A.\tAv. Brigadeiro Faria Lima, 2170\tSão José dos Campos\tSP\tBrazil\t12227-000\t+55 (12) 3923-5555\t+55 (12) 3923-5566\tluisg@embraer.com.br\t3\n",
+      "2\tLeonie\tKöhler\tNone\tTheodor-Heuss-Straße 34\tStuttgart\tNone\tGermany\t70174\t+49 0711 2842222\tNone\tleonekohler@surfeu.de\t5\n",
+      "3\tFrançois\tTremblay\tNone\t1498 rue Bélanger\tMontréal\tQC\tCanada\tH2G 1A7\t+1 (514) 721-4711\tNone\tftremblay@gmail.com\t3\n",
+      "*/\n",
+      "\n",
+      "\n",
+      "CREATE TABLE \"Invoice\" (\n",
+      "\t\"InvoiceId\" INTEGER NOT NULL, \n",
+      "\t\"CustomerId\" INTEGER NOT NULL, \n",
+      "\t\"InvoiceDate\" DATETIME NOT NULL, \n",
+      "\t\"BillingAddress\" NVARCHAR(70), \n",
+      "\t\"BillingCity\" NVARCHAR(40), \n",
+      "\t\"BillingState\" NVARCHAR(40), \n",
+      "\t\"BillingCountry\" NVARCHAR(40), \n",
+      "\t\"BillingPostalCode\" NVARCHAR(10), \n",
+      "\t\"Total\" NUMERIC(10, 2) NOT NULL, \n",
+      "\tPRIMARY KEY (\"InvoiceId\"), \n",
+      "\tFOREIGN KEY(\"CustomerId\") REFERENCES \"Customer\" (\"CustomerId\")\n",
+      ")\n",
+      "\n",
+      "/*\n",
+      "3 rows from Invoice table:\n",
+      "InvoiceId\tCustomerId\tInvoiceDate\tBillingAddress\tBillingCity\tBillingState\tBillingCountry\tBillingPostalCode\tTotal\n",
+      "1\t2\t2021-01-01 00:00:00\tTheodor-Heuss-Straße 34\tStuttgart\tNone\tGermany\t70174\t1.98\n",
+      "2\t4\t2021-01-02 00:00:00\tUllevålsveien 14\tOslo\tNone\tNorway\t0171\t3.96\n",
+      "3\t8\t2021-01-03 00:00:00\tGrétrystraat 63\tBrussels\tNone\tBelgium\t1000\t5.94\n",
+      "*/\u001b[0m\u001b[32;1m\u001b[1;3m\n",
+      "Invoking: `sql_db_query` with `{'query': 'SELECT c.FirstName, c.LastName, SUM(i.Total) AS TotalSpent FROM Customer c JOIN Invoice i ON c.CustomerId = i.CustomerId GROUP BY c.CustomerId ORDER BY TotalSpent DESC LIMIT 1;'}`\n",
+      "responded: The Customer table contains information about each customer's ID, name, company, address, city, state, country, postal code, phone number, fax, email, and support representative ID. The Invoice table contains information about each invoice's ID, customer ID, date, billing address, billing city, billing state, billing country, billing postal code, and total amount.\n",
+      "\n",
+      "To answer the user's question, I will write a SQL query to find the customer who has spent the most money.\n",
+      "\n",
+      "\u001b[0m\u001b[36;1m\u001b[1;3m[('Helena', 'Holý', 49.62)]\u001b[0m\u001b[32;1m\u001b[1;3mThe best customer is Helena Holý, who has spent a total of 49.62.\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'input': 'who is the best customer? The customer who has spent the most money is the best. Please write and execute the correct sql query to answer this question, and give me the result!',\n",
+       " 'output': 'The best customer is Helena Holý, who has spent a total of 49.62.'}"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "agent_executor.invoke({\n",
+    "   \"input\": \"who is the best customer? The customer who has spent the most money is the best. Please write and execute the correct sql query to answer this question, and give me the result!\",\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19d68263",
+   "metadata": {},
+   "source": [
+    "The agent is able to execute and query the relevant tables, including performing necessary table joins to answer the user query."
    ]
   },
   {
@@ -35,8 +286,27 @@
     "collapsed": false
    },
    "source": [
-    "<a id=\"sec_step0\"></a>\n",
-    "# Toolkit Setup\n",
+    "<a id=\"sec_step1\"></a>\n",
+    "# SQL Agent using Cohere ReAct Agent\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a2802ee",
+   "metadata": {},
+   "source": [
+    "In the above section, we made use of an built in abstraction from langchain to perform question answering over a db knowledge source. \n",
+    "Let us now build a similar agent from the ground up and understand better how the different components like tools, prompts and function calling work hand in hand to enable a succesful agent implementation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40282553",
+   "metadata": {},
+   "source": [
+    "<a id=\"sec_step2\"></a>\n",
+    "## Toolkit Setup\n",
     "\n"
    ]
   },
@@ -148,8 +418,8 @@
    "id": "7554c397-76ae-46c8-9c76-b906f926febf",
    "metadata": {},
    "source": [
-    "<a id=\"sec_step1\"></a>\n",
-    "# SQL Agent\n",
+    "<a id=\"sec_step3\"></a>\n",
+    "## SQL Agent\n",
     "\n",
     "we follow the general cohere react agent setup in Langchain to build our SQL agent."
    ]
@@ -191,16 +461,16 @@
      "text": [
       "\n",
       "\n",
-      "\u001B[1m> Entering new AgentExecutor chain...\u001B[0m\n",
-      "\u001B[32;1m\u001B[1;3m\n",
+      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3m\n",
       "I will use the sql_db_list_tables tool to find out what tables are available.\n",
       "{'tool_name': 'sql_db_list_tables', 'parameters': {'tool_input': ''}}\n",
-      "\u001B[0m\u001B[38;5;200m\u001B[1;3mAlbum, Artist, Customer, Employee, Genre, Invoice, InvoiceLine, MediaType, Playlist, PlaylistTrack, Track\u001B[0m\u001B[32;1m\u001B[1;3mRelevant Documents: 0\n",
+      "\u001b[0m\u001b[38;5;200m\u001b[1;3mAlbum, Artist, Customer, Employee, Genre, Invoice, InvoiceLine, MediaType, Playlist, PlaylistTrack, Track\u001b[0m\u001b[32;1m\u001b[1;3mRelevant Documents: 0\n",
       "Cited Documents: 0\n",
       "Answer: The following tables are available: Album, Artist, Customer, Employee, Genre, Invoice, InvoiceLine, MediaType, Playlist, PlaylistTrack, Track.\n",
-      "Grounded answer: The following tables are available: <co: 0>Album</co: 0>, <co: 0>Artist</co: 0>, <co: 0>Customer</co: 0>, <co: 0>Employee</co: 0>, <co: 0>Genre</co: 0>, <co: 0>Invoice</co: 0>, <co: 0>InvoiceLine</co: 0>, <co: 0>MediaType</co: 0>, <co: 0>Playlist</co: 0>, <co: 0>PlaylistTrack</co: 0>, <co: 0>Track</co: 0>.\u001B[0m\n",
+      "Grounded answer: The following tables are available: <co: 0>Album</co: 0>, <co: 0>Artist</co: 0>, <co: 0>Customer</co: 0>, <co: 0>Employee</co: 0>, <co: 0>Genre</co: 0>, <co: 0>Invoice</co: 0>, <co: 0>InvoiceLine</co: 0>, <co: 0>MediaType</co: 0>, <co: 0>Playlist</co: 0>, <co: 0>PlaylistTrack</co: 0>, <co: 0>Track</co: 0>.\u001b[0m\n",
       "\n",
-      "\u001B[1m> Finished chain.\u001B[0m\n"
+      "\u001b[1m> Finished chain.\u001b[0m\n"
      ]
     },
     {
@@ -258,11 +528,11 @@
      "text": [
       "\n",
       "\n",
-      "\u001B[1m> Entering new AgentExecutor chain...\u001B[0m\n",
-      "\u001B[32;1m\u001B[1;3m\n",
+      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3m\n",
       "I will use the sql_db_schema tool to find the first row of the Playlist and Genre tables.\n",
       "{'tool_name': 'sql_db_schema', 'parameters': {'table_names': 'Playlist, Genre'}}\n",
-      "\u001B[0m\u001B[33;1m\u001B[1;3m\n",
+      "\u001b[0m\u001b[33;1m\u001b[1;3m\n",
       "CREATE TABLE \"Genre\" (\n",
       "\t\"GenreId\" INTEGER NOT NULL, \n",
       "\t\"Name\" NVARCHAR(120), \n",
@@ -290,7 +560,7 @@
       "1\tMusic\n",
       "2\tMovies\n",
       "3\tTV Shows\n",
-      "*/\u001B[0m\u001B[32;1m\u001B[1;3mRelevant Documents: 0\n",
+      "*/\u001b[0m\u001b[32;1m\u001b[1;3mRelevant Documents: 0\n",
       "Cited Documents: 0\n",
       "Answer: Here is the first row of the Genre table:\n",
       "\n",
@@ -313,9 +583,9 @@
       "\n",
       "| <co: 0>PlaylistId</co: 0> | <co: 0>Name</co: 0> |\n",
       "| --- | --- |\n",
-      "| <co: 0>1</co: 0> | <co: 0>Music</co: 0> |\u001B[0m\n",
+      "| <co: 0>1</co: 0> | <co: 0>Music</co: 0> |\u001b[0m\n",
       "\n",
-      "\u001B[1m> Finished chain.\u001B[0m\n"
+      "\u001b[1m> Finished chain.\u001b[0m\n"
      ]
     },
     {
@@ -366,24 +636,24 @@
      "text": [
       "\n",
       "\n",
-      "\u001B[1m> Entering new AgentExecutor chain...\u001B[0m\n",
-      "\u001B[32;1m\u001B[1;3m\n",
+      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3m\n",
       "I will search for the number of invoices per country and then write an answer based on the results.\n",
       "{'tool_name': 'sql_db_query', 'parameters': {'query': 'SELECT country, COUNT(*) AS invoice_count FROM invoices GROUP BY country ORDER BY invoice_count DESC'}}\n",
-      "\u001B[0m\u001B[36;1m\u001B[1;3mError: (sqlite3.OperationalError) no such table: invoices\n",
+      "\u001b[0m\u001b[36;1m\u001b[1;3mError: (sqlite3.OperationalError) no such table: invoices\n",
       "[SQL: SELECT country, COUNT(*) AS invoice_count FROM invoices GROUP BY country ORDER BY invoice_count DESC]\n",
-      "(Background on this error at: https://sqlalche.me/e/20/e3q8)\u001B[0m\u001B[32;1m\u001B[1;3m\n",
+      "(Background on this error at: https://sqlalche.me/e/20/e3q8)\u001b[0m\u001b[32;1m\u001b[1;3m\n",
       "I received an error message. I will now use the sql_db_list_tables tool to find out the name of the table containing the invoices data.\n",
       "{'tool_name': 'sql_db_list_tables', 'parameters': {'tool_input': ''}}\n",
-      "\u001B[0m\u001B[38;5;200m\u001B[1;3mAlbum, Artist, Customer, Employee, Genre, Invoice, InvoiceLine, MediaType, Playlist, PlaylistTrack, Track\u001B[0m\u001B[32;1m\u001B[1;3m\n",
+      "\u001b[0m\u001b[38;5;200m\u001b[1;3mAlbum, Artist, Customer, Employee, Genre, Invoice, InvoiceLine, MediaType, Playlist, PlaylistTrack, Track\u001b[0m\u001b[32;1m\u001b[1;3m\n",
       "I found out that the table name is 'Invoice'. I will now rewrite my query and run it again.\n",
       "{'tool_name': 'sql_db_query', 'parameters': {'query': 'SELECT country, COUNT(*) AS invoice_count FROM Invoice GROUP BY country ORDER BY invoice_count DESC'}}\n",
-      "\u001B[0m\u001B[36;1m\u001B[1;3mError: (sqlite3.OperationalError) no such column: country\n",
+      "\u001b[0m\u001b[36;1m\u001b[1;3mError: (sqlite3.OperationalError) no such column: country\n",
       "[SQL: SELECT country, COUNT(*) AS invoice_count FROM Invoice GROUP BY country ORDER BY invoice_count DESC]\n",
-      "(Background on this error at: https://sqlalche.me/e/20/e3q8)\u001B[0m\u001B[32;1m\u001B[1;3m\n",
+      "(Background on this error at: https://sqlalche.me/e/20/e3q8)\u001b[0m\u001b[32;1m\u001b[1;3m\n",
       "I received another error message. I will now use the sql_db_schema tool to find out the column names in the 'Invoice' table.\n",
       "{'tool_name': 'sql_db_schema', 'parameters': {'table_names': 'Invoice'}}\n",
-      "\u001B[0m\u001B[33;1m\u001B[1;3m\n",
+      "\u001b[0m\u001b[33;1m\u001b[1;3m\n",
       "CREATE TABLE \"Invoice\" (\n",
       "\t\"InvoiceId\" INTEGER NOT NULL, \n",
       "\t\"CustomerId\" INTEGER NOT NULL, \n",
@@ -404,15 +674,15 @@
       "1\t2\t2021-01-01 00:00:00\tTheodor-Heuss-Straße 34\tStuttgart\tNone\tGermany\t70174\t1.98\n",
       "2\t4\t2021-01-02 00:00:00\tUllevålsveien 14\tOslo\tNone\tNorway\t0171\t3.96\n",
       "3\t8\t2021-01-03 00:00:00\tGrétrystraat 63\tBrussels\tNone\tBelgium\t1000\t5.94\n",
-      "*/\u001B[0m\u001B[32;1m\u001B[1;3m\n",
+      "*/\u001b[0m\u001b[32;1m\u001b[1;3m\n",
       "I found out that the column name for country is 'BillingCountry'. I will now rewrite my query and run it again.\n",
       "{'tool_name': 'sql_db_query', 'parameters': {'query': 'SELECT BillingCountry AS country, COUNT(*) AS invoice_count FROM Invoice GROUP BY country ORDER BY invoice_count DESC'}}\n",
-      "\u001B[0m\u001B[36;1m\u001B[1;3m[('USA', 91), ('Canada', 56), ('France', 35), ('Brazil', 35), ('Germany', 28), ('United Kingdom', 21), ('Portugal', 14), ('Czech Republic', 14), ('India', 13), ('Sweden', 7), ('Spain', 7), ('Poland', 7), ('Norway', 7), ('Netherlands', 7), ('Italy', 7), ('Ireland', 7), ('Hungary', 7), ('Finland', 7), ('Denmark', 7), ('Chile', 7), ('Belgium', 7), ('Austria', 7), ('Australia', 7), ('Argentina', 7)]\u001B[0m\u001B[32;1m\u001B[1;3mRelevant Documents: 1,3,4\n",
+      "\u001b[0m\u001b[36;1m\u001b[1;3m[('USA', 91), ('Canada', 56), ('France', 35), ('Brazil', 35), ('Germany', 28), ('United Kingdom', 21), ('Portugal', 14), ('Czech Republic', 14), ('India', 13), ('Sweden', 7), ('Spain', 7), ('Poland', 7), ('Norway', 7), ('Netherlands', 7), ('Italy', 7), ('Ireland', 7), ('Hungary', 7), ('Finland', 7), ('Denmark', 7), ('Chile', 7), ('Belgium', 7), ('Austria', 7), ('Australia', 7), ('Argentina', 7)]\u001b[0m\u001b[32;1m\u001b[1;3mRelevant Documents: 1,3,4\n",
       "Cited Documents: 4\n",
       "Answer: The countries with the most invoices are the USA (91), Canada (56), and France (35).\n",
-      "Grounded answer: The countries with the most invoices are the <co: 4>USA (91</co: 4>), <co: 4>Canada (56</co: 4>), and <co: 4>France (35</co: 4>).\u001B[0m\n",
+      "Grounded answer: The countries with the most invoices are the <co: 4>USA (91</co: 4>), <co: 4>Canada (56</co: 4>), and <co: 4>France (35</co: 4>).\u001b[0m\n",
       "\n",
-      "\u001B[1m> Finished chain.\u001B[0m\n"
+      "\u001b[1m> Finished chain.\u001b[0m\n"
      ]
     },
     {
@@ -466,19 +736,19 @@
      "text": [
       "\n",
       "\n",
-      "\u001B[1m> Entering new AgentExecutor chain...\u001B[0m\n",
-      "\u001B[32;1m\u001B[1;3m\n",
+      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3m\n",
       "I will search for the customer who has spent the most money and write an answer based on the results.\n",
       "{'tool_name': 'sql_db_query', 'parameters': {'query': 'SELECT customer_name, SUM(total_price) AS total_spent FROM orders GROUP BY customer_name ORDER BY total_spent DESC LIMIT 1;'}}\n",
-      "\u001B[0m\u001B[36;1m\u001B[1;3mError: (sqlite3.OperationalError) no such table: orders\n",
+      "\u001b[0m\u001b[36;1m\u001b[1;3mError: (sqlite3.OperationalError) no such table: orders\n",
       "[SQL: SELECT customer_name, SUM(total_price) AS total_spent FROM orders GROUP BY customer_name ORDER BY total_spent DESC LIMIT 1;]\n",
-      "(Background on this error at: https://sqlalche.me/e/20/e3q8)\u001B[0m\u001B[32;1m\u001B[1;3m\n",
+      "(Background on this error at: https://sqlalche.me/e/20/e3q8)\u001b[0m\u001b[32;1m\u001b[1;3m\n",
       "I received an error message. I will now use the sql_db_list_tables tool to find out which tables are available.\n",
       "{'tool_name': 'sql_db_list_tables', 'parameters': {'tool_input': ''}}\n",
-      "\u001B[0m\u001B[38;5;200m\u001B[1;3mAlbum, Artist, Customer, Employee, Genre, Invoice, InvoiceLine, MediaType, Playlist, PlaylistTrack, Track\u001B[0m\u001B[32;1m\u001B[1;3m\n",
+      "\u001b[0m\u001b[38;5;200m\u001b[1;3mAlbum, Artist, Customer, Employee, Genre, Invoice, InvoiceLine, MediaType, Playlist, PlaylistTrack, Track\u001b[0m\u001b[32;1m\u001b[1;3m\n",
       "I found that there is a 'Customer' table and an 'Invoice' table. I will now use the sql_db_schema tool to find out more about these tables.\n",
       "{'tool_name': 'sql_db_schema', 'parameters': {'table_names': 'Customer,Invoice'}}\n",
-      "\u001B[0m\u001B[33;1m\u001B[1;3m\n",
+      "\u001b[0m\u001b[33;1m\u001b[1;3m\n",
       "CREATE TABLE \"Customer\" (\n",
       "\t\"CustomerId\" INTEGER NOT NULL, \n",
       "\t\"FirstName\" NVARCHAR(40) NOT NULL, \n",
@@ -526,15 +796,15 @@
       "1\t2\t2021-01-01 00:00:00\tTheodor-Heuss-Straße 34\tStuttgart\tNone\tGermany\t70174\t1.98\n",
       "2\t4\t2021-01-02 00:00:00\tUllevålsveien 14\tOslo\tNone\tNorway\t0171\t3.96\n",
       "3\t8\t2021-01-03 00:00:00\tGrétrystraat 63\tBrussels\tNone\tBelgium\t1000\t5.94\n",
-      "*/\u001B[0m\u001B[32;1m\u001B[1;3m\n",
+      "*/\u001b[0m\u001b[32;1m\u001b[1;3m\n",
       "I found that the 'Customer' table contains information about customers, including their names, addresses, and phone numbers. The 'Invoice' table contains information about invoices, including the customer ID, invoice date, and total amount. I will now write a new query to find the customer who has spent the most money.\n",
       "{'tool_name': 'sql_db_query', 'parameters': {'query': 'SELECT c.FirstName, c.LastName, SUM(i.Total) AS total_spent FROM Customer c JOIN Invoice i ON c.CustomerId = i.CustomerId GROUP BY c.CustomerId ORDER BY total_spent DESC LIMIT 1;'}}\n",
-      "\u001B[0m\u001B[36;1m\u001B[1;3m[('Helena', 'Holý', 49.62)]\u001B[0m\u001B[32;1m\u001B[1;3mRelevant Documents: 1,2,3\n",
+      "\u001b[0m\u001b[36;1m\u001b[1;3m[('Helena', 'Holý', 49.62)]\u001b[0m\u001b[32;1m\u001b[1;3mRelevant Documents: 1,2,3\n",
       "Cited Documents: 3\n",
       "Answer: The best customer is Helena Holý, who has spent a total of 49.62.\n",
-      "Grounded answer: The best customer is <co: 3>Helena Holý</co: 3>, who has spent a total of <co: 3>49.62</co: 3>.\u001B[0m\n",
+      "Grounded answer: The best customer is <co: 3>Helena Holý</co: 3>, who has spent a total of <co: 3>49.62</co: 3>.\u001b[0m\n",
       "\n",
-      "\u001B[1m> Finished chain.\u001B[0m\n"
+      "\u001b[1m> Finished chain.\u001b[0m\n"
      ]
     },
     {
@@ -578,8 +848,8 @@
    "id": "1c9ea4d9-8f92-4780-b33e-e348b2fa854f",
    "metadata": {},
    "source": [
-    "<a id=\"sec_step2\"></a>\n",
-    "# SQL Agent with context"
+    "<a id=\"sec_step4\"></a>\n",
+    "## SQL Agent with context"
    ]
   },
   {
@@ -654,16 +924,16 @@
      "text": [
       "\n",
       "\n",
-      "\u001B[1m> Entering new AgentExecutor chain...\u001B[0m\n",
-      "\u001B[32;1m\u001B[1;3m\n",
+      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n",
+      "\u001b[32;1m\u001b[1;3m\n",
       "I will write a SQL query to find the customer who has spent the most money.\n",
       "{'tool_name': 'sql_db_query', 'parameters': {'query': 'SELECT c.CustomerId, c.FirstName, c.LastName, SUM(i.Total) AS TotalSpent\\nFROM Customer c\\nJOIN Invoice i ON c.CustomerId = i.CustomerId\\nGROUP BY c.CustomerId\\nORDER BY TotalSpent DESC\\nLIMIT 1;'}}\n",
-      "\u001B[0m\u001B[36;1m\u001B[1;3m[(6, 'Helena', 'Holý', 49.62)]\u001B[0m\u001B[32;1m\u001B[1;3mRelevant Documents: 0\n",
+      "\u001b[0m\u001b[36;1m\u001b[1;3m[(6, 'Helena', 'Holý', 49.62)]\u001b[0m\u001b[32;1m\u001b[1;3mRelevant Documents: 0\n",
       "Cited Documents: 0\n",
       "Answer: The customer who has spent the most money is Helena Holý.\n",
-      "Grounded answer: The customer who has spent the most money is <co: 0>Helena Holý</co: 0>.\u001B[0m\n",
+      "Grounded answer: The customer who has spent the most money is <co: 0>Helena Holý</co: 0>.\u001b[0m\n",
       "\n",
-      "\u001B[1m> Finished chain.\u001B[0m\n"
+      "\u001b[1m> Finished chain.\u001b[0m\n"
      ]
     },
     {
@@ -725,7 +995,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/notebooks/agents/sql_agent/sql_agent.ipynb
+++ b/notebooks/agents/sql_agent/sql_agent.ipynb
@@ -21,6 +21,8 @@
     "## Objective\n",
     "In this notebook we explore how to setup a sql agent using langchain and Cohere models. We explore two ways to achieve this, one using the [create_sql_agent](https://api.python.langchain.com/en/latest/sql_agent/langchain_cohere.sql_agent.agent.create_sql_agent.html) abstraction from langchain-cohere, and another using the [Cohere ReAct Agent](https://github.com/langchain-ai/langchain-cohere/blob/main/libs/cohere/langchain_cohere/cohere_agent.py) to answer questions over SQL Databases. We show how this can be done seamlessly with langchain's existing SQLDBToolkit.\n",
     "\n",
+    "The [create_sql_agent](https://api.python.langchain.com/en/latest/sql_agent/langchain_cohere.sql_agent.agent.create_sql_agent.html) option is recommended for most use cases and can be setup without much hassle.\n",
+    "\n",
     "## Table of Contents\n",
     "\n",
     "- [SQL Agent with create_sql_agent](#sec_step0)\n",

--- a/notebooks/agents/sql_agent/sql_agent.ipynb
+++ b/notebooks/agents/sql_agent/sql_agent.ipynb
@@ -89,7 +89,7 @@
     "DB_NAME='Chinook.db'\n",
     "MODEL=\"command-r-plus\"\n",
     "\n",
-    "llm = ChatCohere(model=MODEL, temperature=0.1,verbose=True, cohere_api_key=\"b8CMN0hK0ZYJaXUe9B6FqHdXxKNsT6SVSDq9Cuad\")\n",
+    "llm = ChatCohere(model=MODEL, temperature=0.1,verbose=True)\n",
     "db = SQLDatabase.from_uri(f\"sqlite:///{DB_NAME}\")"
    ]
   },


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR adds a `.gitignore file and updates the `sql_agent.ipynb` notebook.

## .gitignore
A `.gitignore file is added to the repository to specify intentionally untracked files and directories. This helps to keep the repository clean and prevents accidentally committing sensitive files.

## sql_agent.ipynb
The notebook is updated to demonstrate two ways of setting up a SQL agent:
- Using the `create_sql_agent` abstraction from `langchain-cohere`.
- Using the `Cohere ReAct Agent` from `langchain.

The notebook showcases how to use these agents to answer questions over SQL databases seamlessly with `langchain`'s existing `SQLDBToolkit`. It includes code snippets and explanations for setting up the agents, loading the Cohere API key, and invoking the agents to query and manipulate data from a sample database.

<!-- end-generated-description -->