### PR TITLE
Update aws llmu notebook

### DIFF
--- a/notebooks/llmu/co_aws_ch5_rerank_sm.ipynb
+++ b/notebooks/llmu/co_aws_ch5_rerank_sm.ipynb
@@ -145,7 +145,7 @@
     "\n",
     "co_aws = Client(region_name=region)\n",
     "\n",
-    "co_aws.create_endpoint(arn=model_package_arn, endpoint_name=\"my-rerank-v3\", instance_type=\"ml.g5.xlarge\", n_instances=1, role=\"ServiceRoleSagemaker\")"
+    "co_aws.create_endpoint(arn=model_package_arn, endpoint_name=\"my-rerank-v3\", instance_type=\"ml.g5.xlarge\", n_instances=1)"
    ]
   },
   {
@@ -205,7 +205,11 @@
    "source": [
     "query = 'What emails have been about refunds?'\n",
     "\n",
-    "response = co.rerank(documents=documents, query=query, rank_fields=[\"Title\",\"Content\"], top_n=3, model=\"my-rerank-v3\")"
+    "response = co.rerank(documents=documents,\n",
+    "                     query=query,\n",
+    "                     rank_fields=[\"Title\",\"Content\"],\n",
+    "                     top_n=3,\n",
+    "                     model=\"my-rerank-v3\")"
    ]
   },
   {

--- a/notebooks/llmu/co_aws_ch6_rag_bedrock_sm.ipynb
+++ b/notebooks/llmu/co_aws_ch6_rag_bedrock_sm.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install cohere hnswlib unstructured -q"
+    "! pip install cohere cohere-aws boto3 hnswlib unstructured -q"
    ]
   },
   {
@@ -355,25 +355,6 @@
    "outputs": [],
    "source": [
     "class Vectorstore:\n",
-    "    \"\"\"\n",
-    "    A class representing a collection of documents indexed into a vectorstore.\n",
-    "\n",
-    "    Parameters:\n",
-    "    raw_documents (list): A list of dictionaries representing the sources of the raw documents. Each dictionary should have 'title' and 'url' keys.\n",
-    "\n",
-    "    Attributes:\n",
-    "    raw_documents (list): A list of dictionaries representing the raw documents.\n",
-    "    docs (list): A list of dictionaries representing the chunked documents, with 'title', 'text', and 'url' keys.\n",
-    "    docs_embs (list): A list of the associated embeddings for the document chunks.\n",
-    "    docs_len (int): The number of document chunks in the collection.\n",
-    "    idx (hnswlib.Index): The index used for document retrieval.\n",
-    "\n",
-    "    Methods:\n",
-    "    load_and_chunk(): Loads the data from the sources and partitions the HTML content into chunks.\n",
-    "    embed(): Embeds the document chunks using the Cohere API.\n",
-    "    index(): Indexes the document chunks for efficient retrieval.\n",
-    "    retrieve(): Retrieves document chunks based on the given query.\n",
-    "    \"\"\"\n",
     "\n",
     "    def __init__(self, raw_documents: List[Dict[str, str]]):\n",
     "        self.raw_documents = raw_documents\n",
@@ -574,7 +555,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def run_chatbot(message, chat_history=[]):\n",
+    "def run_chatbot(message, chat_history=None):\n",
+    "    \n",
+    "    if chat_history is None:\n",
+    "        chat_history = []\n",
     "    \n",
     "    # Generate search queries, if any        \n",
     "    response = co_br.chat(message=message,\n",

--- a/notebooks/llmu/co_aws_ch8_ft_command.ipynb
+++ b/notebooks/llmu/co_aws_ch8_ft_command.ipynb
@@ -138,7 +138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s3_data_dir = f\"s3://YOUR_S3_PATH\"  # Do not add a trailing slash otherwise the upload will not work"
+    "s3_data_dir = f\"s3://YOUR_S3_DATA_PATH\"  # Do not add a trailing slash otherwise the upload will not work"
    ]
   },
   {
@@ -216,7 +216,7 @@
     "# TODO update this with a custom S3 path\n",
     "# DO NOT re-use the same s3 directory for multiple finetunes\n",
     "# DO NOT add a trailing slash at the end\n",
-    "s3_models_dir = f\"s3://YOUR_S3_PATH\"  "
+    "s3_models_dir = f\"s3://YOUR_S3_MODEL_PATH\"  "
    ]
   },
   {


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request makes updates to three Jupyter notebooks: `co_aws_ch5_rerank_sm.ipynb`, `co_aws_ch6_rag_bedrock_sm.ipynb`, and `co_aws_ch8_ft_command.ipynb`.

## `co_aws_ch5_rerank_sm.ipynb`
The changes in this notebook involve:
- Removing the `role` parameter from the `co_aws.create_endpoint` method invocation.
- Reformatting the `co.rerank` method invocation for better readability by adding line breaks and indentation.

## `co_aws_ch6_rag_bedrock_sm.ipynb`
The updates in this notebook include:
- Adding `cohere` and `boto3` to the `pip install` command.
- Removing the `Vectorstore` class definition and its associated docstrings and attributes.
- Modifying the `run_chatbot` function to accept `None` as a default value for the `chat_history` parameter and initializing an empty list if `None` is provided.

## `co_aws_ch8_ft_command.ipynb`
The notebook has been updated to:
- Change `s3_data_dir` to use `YOUR_S3_DATA_PATH` instead of `YOUR_S3_PATH`.
- Update `s3_models_dir` to use `YOUR_S3_MODEL_PATH` instead of `YOUR_S3_PATH`.

<!-- end-generated-description -->