### PR TITLE
docs: drop urls from notebooks

### DIFF
--- a/notebooks/Embed_Jobs_Semantic_Search.ipynb
+++ b/notebooks/Embed_Jobs_Semantic_Search.ipynb
@@ -17,8 +17,8 @@
       },
       "outputs": [],
       "source": [
-        "# TODO: upgrade to \"cohere>5\"",
-"! pip install \"cohere<5\" hnswlib -q"
+        "# TODO: upgrade to \"cohere>5\"\n",
+        "! pip install \"cohere<5\" hnswlib -q"
       ]
     },
     {
@@ -89,25 +89,7 @@
         "id": "3lAS4bcvCplJ",
         "outputId": "5e1fcd0b-4880-43ed-d8a4-03148b2ef047"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "cohere.Dataset {\n",
-            "\tid: sample-file-hca4x0\n",
-            "\tname: sample_file\n",
-            "\tdataset_type: embed-input\n",
-            "\tvalidation_status: validated\n",
-            "\tcreated_at: 2024-01-13 02:51:48.215973\n",
-            "\tupdated_at: 2024-01-13 02:51:48.215973\n",
-            "\tdownload_urls: ['https://storage.googleapis.com/cohere-user/dataset-api-temp/d489c39a-e152-49da-9ddc-9801bd74d823/f8bd5ab1-ccdf-45e6-9717-23b8be1ff39d/sample-file-hca4x0/000_embed_jobs_sample_data.avro?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=dataset%40cohere-production.iam.gserviceaccount.com%2F20240113%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20240113T025159Z&X-Goog-Expires=14399&X-Goog-Signature=7f9ed7cb27988e4bf447167160b25940cd106859d1282919604a0d74b882681b5aaa3245f97555bb61ddca7fd9c02fb0bba8391433c70aeb2118607dfd534db444097c5ae9c8d07e66bf6723a64634f5d6f5b2500c82e351807203f5fd3c278b2584c258b4c6afc6ee191e63bcd346e3dd2c7fd4b171c2d3ddfe8e6e68c2522111b6f63e125a052be9ebe3302903f4bef9cd165c8e075b168e621c7c61177a0973bb470cc3535457078e18b338884fb303792a1ba3161ab5ca5ce2adca5676754ee1a735891ccbf64cca03d3fdcabdcccd0d201600b8c70e13487bf897f2b88424cc736f8bf8756ec835b09dacf0aa20dc8151d9249b21d4ca4de82144fcd8be&X-Goog-SignedHeaders=host']\n",
-            "\tvalidation_error: None\n",
-            "\tvalidation_warnings: []\n",
-            "}\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "print(ds.await_validation())"
       ]
@@ -162,35 +144,7 @@
         "id": "LEevvN2XCUpR",
         "outputId": "d123c0a4-0c6a-4235-9ba8-658d5d3ec358"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "cohere.EmbedJob {\n",
-            "\tjob_id: 792bbc1a-561b-48c2-8a97-0c80c1914ea8\n",
-            "\tstatus: complete\n",
-            "\tcreated_at: 2024-01-13T02:53:31.879719Z\n",
-            "\tinput_dataset_id: sample-file-hca4x0\n",
-            "\toutput_urls: None\n",
-            "\tmodel: embed-english-v3.0\n",
-            "\ttruncate: RIGHT\n",
-            "\tpercent_complete: 100\n",
-            "\toutput: cohere.Dataset {\n",
-            "\tid: embeded-sample-file-drtjf9\n",
-            "\tname: embeded-sample-file\n",
-            "\tdataset_type: embed-result\n",
-            "\tvalidation_status: validated\n",
-            "\tcreated_at: 2024-01-13 02:53:33.569362\n",
-            "\tupdated_at: 2024-01-13 02:53:33.569362\n",
-            "\tdownload_urls: ['https://storage.googleapis.com/cohere-user/dataset-api-temp/d489c39a-e152-49da-9ddc-9801bd74d823/f8bd5ab1-ccdf-45e6-9717-23b8be1ff39d/embeded-sample-file-drtjf9/001_embeded-sample-file.avro?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=dataset%40cohere-production.iam.gserviceaccount.com%2F20240113%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20240113T025352Z&X-Goog-Expires=14399&X-Goog-Signature=927d2d73947058c95cd73f813e87e81416163dd0ccba1d5ce064a186fdc732550a605ff2122c9087fcc8e16dded9836084be532dac59622f73cb625fa1014fa9b1f9b702ca02be50006d8e2b2239870e3c765f7f8bd4964ccc74f4d9cc28672cd22c0d47008b112bd787eaab19692a5d9d724899f6aac088facdbe6d3b9d74f929fa07e76126656a5b0635a9793d9e85e692ca2d1d40f406869a53aa2e7390570d67e602fc5ea1741686176ce857112d5d68dee1b2fc62a436cd244890ec7c5901941cb10b01c2c41d6eba67dc393370a7c47526a7272f1f70f880b5fea2f69cb4546a633440a538fad7b92fdeb28d98aec1680cafc89142053da915268ea039&X-Goog-SignedHeaders=host']\n",
-            "\tvalidation_error: None\n",
-            "\tvalidation_warnings: []\n",
-            "}\n",
-            "}\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "print(job)"
       ]

--- a/notebooks/Embed_Jobs_Serverless_Pinecone_Semantic_Search.ipynb
+++ b/notebooks/Embed_Jobs_Serverless_Pinecone_Semantic_Search.ipynb
@@ -75,34 +75,7 @@
         "id": "G677sKZc6NDv",
         "outputId": "e4bfd9ca-590a-4cf7-d9cf-3657a16e2a7f"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "uploading file, starting validation...\n",
-            "sample-file-2gwgxq was uploaded\n",
-            "...\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "cohere.Dataset {\n",
-            "\tid: sample-file-2gwgxq\n",
-            "\tname: sample_file\n",
-            "\tdataset_type: embed-input\n",
-            "\tvalidation_status: validated\n",
-            "\tcreated_at: 2024-01-13 02:47:32.563080\n",
-            "\tupdated_at: 2024-01-13 02:47:32.563081\n",
-            "\tdownload_urls: ['https://storage.googleapis.com/cohere-user/dataset-api-temp/d489c39a-e152-49da-9ddc-9801bd74d823/96d12a16-2dd4-46f7-9630-1fa9bb0b26ca/sample-file-2gwgxq/000_embed_jobs_sample_data.avro?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=dataset%40cohere-production.iam.gserviceaccount.com%2F20240113%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20240113T024743Z&X-Goog-Expires=14399&X-Goog-Signature=1cc013824d54e4974600e19ec5c5dd6624c3de0c512f1c7d204fa95056b09e19d90c0fe034c59f0eef8bdfd4e1ed03b44c601d290e9b9c9e0643afd7a44fe97c42750304a8f199c9d87abb50fc74d777ab2d36efecca64ad97264f9e0628f2e199b9eb2d505241480a7436191cacaa78efb328567c9303469b653962caf07e6b11fac06ed06bd4597377e87fac58214bab1cd5cde63e19508d903e65ad654a177e27a64105b79c56d0cc156a35b61d45a7dda3b9819ef78dc9861c818b808527a1e16210dc83130be630f1b54c75d280ea20d070566056a6b2c7b1a016409482defc2a1942a801e46f5349adfadb244711da80d103ed831d6927366adc0c1659&X-Goog-SignedHeaders=host']\n",
-            "\tvalidation_error: None\n",
-            "\tvalidation_warnings: []\n",
-            "}\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Upload a dataset for embed jobs\n",
         "dataset_file_path = \"data/embed_jobs_sample_data.jsonl\" # Full path - https://raw.githubusercontent.com/cohere-ai/notebooks/main/notebooks/data/embed_jobs_sample_data.jsonl\n",
@@ -166,35 +139,7 @@
         "id": "d__jANfVvNld",
         "outputId": "c4dcd936-c338-47b3-994d-71cdceaa6796"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "cohere.EmbedJob {\n",
-            "\tjob_id: 6d691fbe-e026-436a-826a-16e70b293e51\n",
-            "\tstatus: complete\n",
-            "\tcreated_at: 2024-01-13T02:47:46.385016Z\n",
-            "\tinput_dataset_id: sample-file-2gwgxq\n",
-            "\toutput_urls: None\n",
-            "\tmodel: embed-english-v3.0\n",
-            "\ttruncate: RIGHT\n",
-            "\tpercent_complete: 100\n",
-            "\toutput: cohere.Dataset {\n",
-            "\tid: embeded-sample-file-mdse2h\n",
-            "\tname: embeded-sample-file\n",
-            "\tdataset_type: embed-result\n",
-            "\tvalidation_status: validated\n",
-            "\tcreated_at: 2024-01-13 02:47:47.850097\n",
-            "\tupdated_at: 2024-01-13 02:47:47.850097\n",
-            "\tdownload_urls: ['https://storage.googleapis.com/cohere-user/dataset-api-temp/d489c39a-e152-49da-9ddc-9801bd74d823/96d12a16-2dd4-46f7-9630-1fa9bb0b26ca/embeded-sample-file-mdse2h/001_embeded-sample-file.avro?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=dataset%40cohere-production.iam.gserviceaccount.com%2F20240113%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20240113T024807Z&X-Goog-Expires=14399&X-Goog-Signature=78b0d82e19388aee2926a4ef403d5f286487d0e7fc9a09c75bfb6700b502fa4f55b024977c0aeae26cd501a41e506bf00d3e850d7d9691298963374f04fa129e8dae5a327389c80921bf611a25386f5e4501b11c9d88bc1aee6f6877157a4675c5f8fe06bb25e3ca2b12da46e5b1da3067ca71bed901cd14db26e09987e355c039f96d6514a0931aa5f8753ddc155ca1782c63e3cb000b095d3b29904982ff75686c716329e92b6946485c567dabc3e344c9a0f9a59416415738b67ead0cca3cdb06c1db64c925ea38a2d92ab4079577e5775367260c09916aab5af67326bca4fa1295ee76457f933a6ca26a5d4ac9c59f0f73286627b2bae3e7fa7375c97465&X-Goog-SignedHeaders=host']\n",
-            "\tvalidation_error: None\n",
-            "\tvalidation_warnings: []\n",
-            "}\n",
-            "}\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "print(job)"
       ]


### PR DESCRIPTION
<!-- begin-generated-description -->

The pull request makes changes to two Jupyter notebooks: `Embed_Jobs_Semantic_Search.ipynb` and `Embed_Jobs_Serverless_Pinecone_Semantic_Search.ipynb`. 

**Summary:**
The changes in this PR remove the output logs from the notebooks, keeping only the essential code and print statements. This improves readability and focuses on the key steps for using the Cohere API to upload and embed datasets.

**Details:**
- `notebooks/Embed_Jobs_Semantic_Search.ipynb`:
  - Removes the output logs for uploading a dataset and creating an embed job.
  - Retains the code for dataset upload and embed job creation, along with the `print(ds.await_validation())` and `print(job)` statements.
- `notebooks/Embed_Jobs_Serverless_Pinecone_Semantic_Search.ipynb`:
  - Deletes the output logs for dataset upload and embed job creation.
  - Keeps the code for dataset upload, embed job creation, and the `print(job)` statement.

<!-- end-generated-description -->