### PR TITLE
Guardrails API updates

### DIFF
--- a/notebooks/llmu/Validating_Large_Language_Model_Outputs.ipynb
+++ b/notebooks/llmu/Validating_Large_Language_Model_Outputs.ipynb
@@ -204,6 +204,7 @@
       },
       "outputs": [],
       "source": [
+        "import os\n",
         "import cohere\n",
         "import guardrails as gd\n",
         "from guardrails.hub import ValidRange, ValidChoices\n",
@@ -212,7 +213,10 @@
         "from typing import List\n",
         "\n",
         "# Create a Cohere client\n",
-        "co = cohere.Client(api_key=\"COHERE_API_KEY\")"
+        "co = cohere.Client(api_key=\"COHERE_API_KEY\")\n",
+        "\n",
+        "# Configure the API key for Guardrails\n",
+        "os.environ[\"COHERE_API_KEY\"]=\"COHERE_API_KEY\""
       ]
     },
     {
@@ -436,8 +440,7 @@
       ],
       "source": [
         "# Initialize a Guard object from the Pydantic model PatientInfo\n",
-        "guard = gd.Guard.from_pydantic(PatientInfo, prompt=PROMPT)\n",
-        "print(guard.base_prompt)"
+        "guard = gd.Guard.from_pydantic(PatientInfo, prompt=PROMPT)"
       ]
     },
     {
@@ -488,10 +491,11 @@
       "source": [
         "# Wrap the Cohere API call with the `guard` object\n",
         "response = guard(\n",
-        "    co.chat,\n",
+        "    instructions=PROMPT,\n",
         "    prompt_params={\"doctors_notes\": doctors_notes},\n",
         "    model='command-r',\n",
         "    temperature=0,\n",
+        "    num_reasks=3,\n",
         ")\n",
         "\n",
         "# Print the validated output from the LLM\n",


### PR DESCRIPTION
# Cells that are not working
`guard.base_prompt` is no longer a property of the resulting guard. 
![Screenshot 2024-09-07 at 6 48 20 AM](https://github.com/user-attachments/assets/7c509075-b168-4907-a6ae-a68f4a9c1650)
After that fix the next error is the actual guard call is throwing an error
![Screenshot 2024-09-07 at 6 48 40 AM](https://github.com/user-attachments/assets/8243892e-13b1-472e-9f08-f0add8468d6a)

# Potential fix
Call the `guard` functions as per the liteLLM instructions [here](https://docs.litellm.ai/docs/providers/cohere) resulting in two changes:
1. Add the `COHERE_API_KEY` to the env vars in the setup cell.
2. Update the arguments to the `guard` function call.

P.S. Thank you for the amazing content on LLMU