### PR TITLE
feat: Add PR template with structured fields

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.yml
@@ -1,0 +1,62 @@
+name: Pull Request
+description: Submit a pull request
+title: "[Type of Change]: [Brief Description]"
+body:
+  - type: dropdown
+    id: change-type
+    attributes:
+      label: Type of Change
+      options:
+        - Bug fix
+        - New feature
+        - Documentation update
+        - Refactor
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What changes does this PR make?
+    validations:
+      required: true
+
+  - type: textarea
+    id: testing
+    attributes:
+      label: Testing
+      description: How have you verified these changes work?
+    validations:
+      required: true
+
+  - type: input
+    id: related-issues
+    attributes:
+      label: Related Issues
+      description: "Add any related issue numbers (e.g., Fixes #123)"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: documentation-checklist
+    attributes:
+      label: Documentation Change Checklist
+      description: Complete this section if this is a documentation change
+      options:
+        - label: I have checked for similar wording/style issues across all documentation
+        - label: I have bundled related improvements together
+        - label: I have verified all links and references still work
+        - label: If this is a single small change, I have explained why it needs to be addressed independently
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        > **Note for documentation updates:** 
+        > - Please check if similar improvements could be made elsewhere in the docs
+        > - Consider bundling multiple small improvements in one PR
+        > - For minor style/flow changes, try to find at least 3-5 similar instances to update together
+        > - If this is a single small change, consider collecting more improvements before submitting

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.yml
@@ -7,14 +7,13 @@ body:
     attributes:
       label: Type of Change
       options:
-        - Bug fix
-        - New feature
+        - New notebook
+        - Notebook update
         - Documentation update
-        - Refactor
+        - Environment/dependency update
         - Other
     validations:
       required: true
-
   - type: textarea
     id: description
     attributes:
@@ -22,15 +21,46 @@ body:
       description: What changes does this PR make?
     validations:
       required: true
-
   - type: textarea
     id: testing
     attributes:
       label: Testing
-      description: How have you verified these changes work?
+      description: |
+        How have you verified these changes work?
+        For notebooks:
+        - Include a screen recording showing execution and outputs
+        - Or include screenshots of key outputs with explanation
+        
+        For documentation:
+        - Preview any markdown changes
+        - Test any new links or references
     validations:
       required: true
-
+  - type: checkboxes
+    id: notebook-checklist
+    attributes:
+      label: Notebook Changes Checklist
+      description: Complete this section if you're modifying notebooks
+      options:
+        - label: I have run the notebook from start to finish without errors
+        - label: I have cleared all cell outputs before committing
+        - label: I have included all required pip installations with pinned versions (e.g., pip install package==1.2.3) in %%sh cells at the start of the notebook
+        - label: I have included a screen recording or screenshots demonstrating the changes
+        - label: I have added sufficient markdown cells to explain the notebook's purpose and usage
+    validations:
+      required: false
+  - type: checkboxes
+    id: documentation-checklist
+    attributes:
+      label: Documentation Changes Checklist
+      description: Complete this section if you're modifying documentation
+      options:
+        - label: I have checked for similar wording/style issues across all documentation
+        - label: I have verified all links and references still work
+        - label: I have previewed how the changes will appear
+        - label: I have followed the repository's documentation style guide (if applicable)
+    validations:
+      required: false
   - type: input
     id: related-issues
     attributes:
@@ -38,25 +68,13 @@ body:
       description: "Add any related issue numbers (e.g., Fixes #123)"
     validations:
       required: false
-
-  - type: checkboxes
-    id: documentation-checklist
-    attributes:
-      label: Documentation Change Checklist
-      description: Complete this section if this is a documentation change
-      options:
-        - label: I have checked for similar wording/style issues across all documentation
-        - label: I have bundled related improvements together
-        - label: I have verified all links and references still work
-        - label: If this is a single small change, I have explained why it needs to be addressed independently
-    validations:
-      required: false
-
   - type: markdown
     attributes:
       value: |
-        > **Note for documentation updates:** 
-        > - Please check if similar improvements could be made elsewhere in the docs
-        > - Consider bundling multiple small improvements in one PR
-        > - For minor style/flow changes, try to find at least 3-5 similar instances to update together
-        > - If this is a single small change, consider collecting more improvements before submitting
+        > **Note for notebook submissions:** 
+        > - Run the notebook in a fresh environment (e.g., new conda env or colab instance) to ensure all dependencies are captured
+        > - Comments should explain the purpose of non-obvious code blocks and any external data dependencies
+
+        > **Note for documentation updates:**
+        > - For minor changes, consider bundling multiple related improvements in one PR
+        > - Look for opportunities to improve similar sections across the documentation


### PR DESCRIPTION
## Type of Change
New feature

## Description
Adds a standardized pull request template with:
- Required fields for change type, description, and testing
- Optional fields for related issues
- Special checklist for documentation changes
- Guidelines for documentation updates

## Testing
- Verified YAML syntax is valid
- Confirmed all field validations work as expected
- Tested template preview in GitHub UI
- Verified markdown formatting displays correctly

## Related Issues
N/A

## Documentation Change Checklist
- [x] I have checked for similar wording/style issues across all documentation
- [x] I have bundled related improvements together
- [x] I have verified all links and references still work
- [x] If this is a single small change, I have explained why it needs to be addressed independently