### PR TITLE
added `(*args, **kwargs)` as parameters to `set_css ()`

### DIFF
--- a/notebooks/llmu/RAG_with_Chat_Embed_and_Rerank.ipynb
+++ b/notebooks/llmu/RAG_with_Chat_Embed_and_Rerank.ipynb
@@ -119,7 +119,7 @@
         "\n",
         "from IPython.display import HTML, display\n",
         "\n",
-        "def set_css():\n",
+        "def set_css(*args, **kwargs):\n",
         "  display(HTML('''\n",
         "  <style>\n",
         "    pre {\n",


### PR DESCRIPTION
added `(*args, **kwargs)` as parameters to `set_css()` so that it can be called with any number of arguments. 

In Jupyter’s event system, callbacks for `pre_run_cell` often receive arguments related to the cell execution context. Therefore, the `set_css` function should be set up to handle these arguments.