### PR TITLE
Update links to sql table

### DIFF
--- a/notebooks/agents/i-5O-sql-agent/sql_agent_demo.ipynb
+++ b/notebooks/agents/i-5O-sql-agent/sql_agent_demo.ipynb
@@ -483,7 +483,7 @@
       "source": [
         "Next, we load the database for our manufacturing data.\n",
         "\n",
-        "We create an in-memory SQLite database using SQL scripts for the `product_tracking` and `status` tables. You can find the the SQL tables [here <todo - link>](<todo>).\n",
+        "We create an in-memory SQLite database using SQL scripts for the `product_tracking` and `status` tables. You can get the [SQL tables here](https://github.com/cohere-ai/notebooks/tree/main/notebooks/agents/i-5O-sql-agent).\n",
         "\n",
         "We then create a SQLDatabase instance, which will be used by our LangChain tools and agents to interact with the data."
       ]


### PR DESCRIPTION
Replaces a TODO placeholder with the actual link to the SQL tables in the GitHub repository.