### PR TITLE
fix: typo for endpoint deletion

### DIFF
--- a/notebooks/finetuning/Command R finetuning sagemaker.ipynb
+++ b/notebooks/finetuning/Command R finetuning sagemaker.ipynb
@@ -424,8 +424,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "co.delete_endpoint()\n",
-    "co.close()"
+    "co.sagemaker_finetuning.delete_endpoint()\n",
+    "co.sagemaker_finetuning.close()"
    ]
   },
   {


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `co.delete_endpoint()` and `co.close()` functions to `co.sagemaker_finetuning.delete_endpoint()` and `co.sagemaker_finetuning.close()` respectively.

- The `co.delete_endpoint()` function is now `co.sagemaker_finetuning.delete_endpoint()`.
- The `co.close()` function is now `co.sagemaker_finetuning.close()`.

<!-- end-generated-description -->