### PR TITLE
Update the guide for rerank with v2

### DIFF
--- a/notebooks/guides/getting-started/v2/tutorial_pt5_v2.ipynb
+++ b/notebooks/guides/getting-started/v2/tutorial_pt5_v2.ipynb
@@ -79,22 +79,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Define the documents\n",
     "faqs_short = [\n",
-    "    {\"text\": \"Reimbursing Travel Expenses: Easily manage your travel expenses by submitting them through our finance tool. Approvals are prompt and straightforward.\"},\n",
-    "    {\"text\": \"Working from Abroad: Working remotely from another country is possible. Simply coordinate with your manager and ensure your availability during core hours.\"},\n",
-    "    {\"text\": \"Health and Wellness Benefits: We care about your well-being and offer gym memberships, on-site yoga classes, and comprehensive health insurance.\"},\n",
-    "    {\"text\": \"Performance Reviews Frequency: We conduct informal check-ins every quarter and formal performance reviews twice a year.\"}\n",
+    "    \"Reimbursing Travel Expenses: Easily manage your travel expenses by submitting them through our finance tool. Approvals are prompt and straightforward.\",\n",
+    "    \"Working from Abroad: Working remotely from another country is possible. Simply coordinate with your manager and ensure your availability during core hours.\",\n",
+    "    \"Health and Wellness Benefits: We care about your well-being and offer gym memberships, on-site yoga classes, and comprehensive health insurance.\",\n",
+    "    \"Performance Reviews Frequency: We conduct informal check-ins every quarter and formal performance reviews twice a year.\"\n",
     "]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -113,7 +113,7 @@
     "results = co.rerank(query=query,\n",
     "                    documents=faqs_short,\n",
     "                    top_n=2,\n",
-    "                    model='rerank-english-v3.0')\n",
+    "                    model='rerank-3.5')\n",
     "\n",
     "print(results)"
    ]
@@ -178,28 +178,30 @@
     "\n",
     "Suppose the new hire now wants to search for any emails about check-in sessions. Let's pretend we have a list of 5 emails retrieved from the email provider's API.\n",
     "\n",
-    "To perform reranking over semi-structured data, we add an additional parameter, `rank_fields`, which contains the list of available fields.\n",
-    "\n",
-    "The model will rerank based on order of the fields passed in. For example, given rank_fields=['title','author','text'], the model will rerank using the values in title, author, and text sequentially. "
+    "To perform reranking over semi-structured data, we serialize the data into a list of yaml strings."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import yaml\n",
+    "\n",
     "# Define the documents\n",
     "emails = [\n",
     "    {\"from\": \"hr@co1t.com\", \"to\": \"david@co1t.com\", \"date\": \"2024-06-24\", \"subject\": \"A Warm Welcome to Co1t!\", \"text\": \"We are delighted to welcome you to the team! As you embark on your journey with us, you'll find attached an agenda to guide you through your first week.\"},\n",
     "    {\"from\": \"it@co1t.com\", \"to\": \"david@co1t.com\", \"date\": \"2024-06-24\", \"subject\": \"Setting Up Your IT Needs\", \"text\": \"Greetings! To ensure a seamless start, please refer to the attached comprehensive guide, which will assist you in setting up all your work accounts.\"},\n",
     "    {\"from\": \"john@co1t.com\", \"to\": \"david@co1t.com\", \"date\": \"2024-06-24\", \"subject\": \"First Week Check-In\", \"text\": \"Hello! I hope you're settling in well. Let's connect briefly tomorrow to discuss how your first week has been going. Also, make sure to join us for a welcoming lunch this Thursday at noon—it's a great opportunity to get to know your colleagues!\"}\n",
-    "]"
+    "]\n",
+    "\n",
+    "yaml_emails = [yaml.dump(email, sort_keys=False) for email in emails]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -223,10 +225,9 @@
     "\n",
     "# Rerank the documents\n",
     "results = co.rerank(query=query,\n",
-    "                    documents=emails,\n",
+    "                    documents=yaml_emails,\n",
     "                    top_n=2,\n",
-    "                    model='rerank-english-v3.0',\n",
-    "                    rank_fields=[\"from\", \"to\", \"date\", \"subject\", \"body\"])\n",
+    "                    model='rerank-v3.5')\n",
     "\n",
     "return_results(results, emails)"
    ]
@@ -249,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -374,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -391,7 +392,8 @@
    "source": [
     "# Define the documents and rank fields\n",
     "employees = df.to_dict('records')\n",
-    "rank_fields = df.columns.tolist()\n",
+    "employees_yaml = [yaml.dump(employee, sort_keys=False) for employee in employees]\n",
+    "\n",
     "\n",
     "# Add the user query\n",
     "query = \"Any full-time product designers who joined recently?\"\n",
@@ -400,8 +402,7 @@
     "results = co.rerank(query=query,\n",
     "                    documents=employees,\n",
     "                    top_n=1,\n",
-    "                    model='rerank-english-v3.0',\n",
-    "                    rank_fields=rank_fields)\n",
+    "                    model='rerank-v3.5')\n",
     "\n",
     "return_results(results, employees)\n"
    ]
@@ -424,7 +425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -450,7 +451,7 @@
     "results = co.rerank(query=query,\n",
     "                    documents=faqs_short,\n",
     "                    top_n=2,\n",
-    "                    model='rerank-multilingual-v3.0')\n",
+    "                    model='rerank-v3.5')\n",
     "\n",
     "return_results(results, faqs_short)"
    ]


### PR DESCRIPTION
<!-- begin-generated-description -->

This pull request updates the code to use the latest version of the `rerank` model, `rerank-v3.5`, for performing reranking over semi-structured data. The changes include:

- Replacing `rerank-english-v3.0` with `rerank-3.5` in the `model` parameter when calling the `co.rerank` function.
- Serializing the data into a list of YAML strings using the `yaml.dump` function and passing it to the `co.rerank` function.
- Removing the `rank_fields` parameter from the `co.rerank` function call.
- Updating the `model` parameter to `rerank-v3.5` in the `co.rerank` function call for both email and employee data.
- Replacing `rerank-multilingual-v3.0` with `rerank-v3.5` in the `model` parameter when calling the `co.rerank` function for FAQ data.

<!-- end-generated-description -->